### PR TITLE
feat(backend): add Flyway with the initial database schema

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -19,6 +19,27 @@ defaults:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+
+    services:
+      # Ephemeral database: created when the job starts and destroyed when it
+      # ends, with no port exposed outside the runner. These are not the
+      # project's credentials — the real ones never enter the repository.
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: calendar_ci
+          POSTGRES_USER: ci
+          POSTGRES_PASSWORD: ci
+        ports:
+          - 5432:5432
+        # Without the health check the job starts before Postgres accepts
+        # connections and the tests fail intermittently.
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -34,6 +55,10 @@ jobs:
         run: chmod +x mvnw
 
       - name: Build and tests
+        env:
+          SPRING_DATASOURCE_URL: jdbc:postgresql://localhost:5432/calendar_ci
+          SPRING_DATASOURCE_USERNAME: ci
+          SPRING_DATASOURCE_PASSWORD: ci
         run: ./mvnw -B clean verify
 
       - name: Publish test reports

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Root-level ignores.
+# Each module has its own .gitignore (backend/, frontend/, mobile/, mobile/android/,
+# mobile/ios/) — only what those don't cover belongs here.
+
+# IDE
+.idea/
+*.iml
+*.iws
+*.ipr
+.vscode/
+
+# Local environment — created from .env.example, holds POSTGRES_PASSWORD
+.env
+.env.local
+.env.*.local
+
+# desktop/ is the only module without its own .gitignore
+desktop/target/
+
+# OS
+.DS_Store
+Thumbs.db

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -37,6 +37,24 @@
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-flyway</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.flywaydb</groupId>
+			<artifactId>flyway-database-postgresql</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>
 			<scope>runtime</scope>
 			<optional>true</optional>

--- a/backend/src/main/java/br/com/calendar/handler/GlobalExceptionHandler.java
+++ b/backend/src/main/java/br/com/calendar/handler/GlobalExceptionHandler.java
@@ -1,0 +1,30 @@
+package br.com.calendar.handler;
+
+import org.jspecify.annotations.NonNull;
+import org.springframework.http.*;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+
+    @Override
+    protected ResponseEntity<@NonNull Object> handleMethodArgumentNotValid(MethodArgumentNotValidException e, HttpHeaders headers,
+                                                                           HttpStatusCode status, WebRequest request) {
+        Map<String, String> campos = new LinkedHashMap<>();
+        e.getBindingResult().getFieldErrors()
+                .forEach(error -> campos.putIfAbsent(error.getField(), error.getDefaultMessage()));
+
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, "Invalid fields");
+        problem.setProperty("campos", campos);
+        return handleExceptionInternal(e, problem, headers, status, request);
+    }
+
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,10 @@
 spring.application.name=calendar
+
+# The datasource comes from SPRING_DATASOURCE_URL / _USERNAME / _PASSWORD in the
+# environment. Spring Boot binds those variables on its own, so no database
+# value needs to be versioned here. See docker-compose.yml and ci-backend.yml.
+
+spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.show-sql=true
+
+spring.flyway.locations=classpath:db/migration

--- a/backend/src/main/resources/db/migration/V1__init_schema.sql
+++ b/backend/src/main/resources/db/migration/V1__init_schema.sql
@@ -1,0 +1,80 @@
+-- V1 - create tables
+CREATE TYPE notification_type AS ENUM ('email', 'notificacao');
+
+
+CREATE TABLE users
+(
+    id              char(21) PRIMARY KEY,
+    avatar          text,
+    name            varchar(200),
+    email           varchar(200),
+    email_confirmed boolean,
+    otp             varchar(8),
+    otp_expiration  timestamp,
+    password        varchar(100),
+    created_at      timestamptz,
+    updated_at      timestamptz
+);
+
+
+CREATE TABLE category
+(
+    id         integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    user_id    char(21) REFERENCES users (id),
+    color      varchar(6),
+    created_at timestamptz,
+    title      varchar
+);
+
+
+CREATE TABLE task
+(
+    all_day         boolean,
+    id              integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    user_id         char(21) REFERENCES users (id),
+    category_id     integer REFERENCES category (id),
+    timezone        text,
+    location        text,
+    title           varchar(255),
+    description     text,
+    status          varchar,
+    starts_at       timestamptz,
+    ends_at         timestamptz,
+    repeat          integer,
+    repeat_interval varchar(15)
+);
+
+
+CREATE TABLE configuration
+(
+    id             integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    user_id        char(21) REFERENCES users (id),
+    theme          varchar,
+    time_format    varchar,
+    update_at      timestamptz,
+    week_start_day varchar,
+    created_at     timestamptz,
+    default_view   varchar
+);
+
+
+CREATE TABLE notification
+(
+    id          integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    user_id     char(21) REFERENCES users (id),
+    time_before timestamptz,
+    type        notification_type,
+    task_id     integer REFERENCES task (id),
+    read        boolean
+);
+
+CREATE TABLE log
+(
+    id         integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    user_id    char(21) REFERENCES users (id),
+    table_name text,
+    table_id   text,
+    type       varchar(32),
+    log        text,
+    created_at timestamptz
+);


### PR DESCRIPTION
## Description

Adds Flyway to the backend and the first migration, translating the project's ER
diagram into the initial database schema.

The backend had no database dependency at all, so the `SPRING_DATASOURCE_*`
variables already injected by docker-compose were being silently ignored. This
adds the PostgreSQL driver, JPA and Flyway, and creates `V1__init_schema.sql`
with the six tables, the `notification_type` enum and the seven foreign keys.

Two names differ from the diagram because they are reserved words in PostgreSQL:
`user` became `users`, and `log.table` became `log.table_name`.

Worth flagging on the Flyway dependency: Spring Boot 4 moved the
auto-configurations into dedicated modules, so `flyway-core` on its own is not
enough. Without `spring-boot-starter-flyway` the application starts successfully
and no migration ever runs, with nothing in the build reporting a problem.

No database value is versioned in `application.properties` — the datasource is
read entirely from the environment, so the real credentials never enter the
repository. The values in `ci-backend.yml` belong to an ephemeral container that
is created and destroyed inside the job.

Also included:

- a root `.gitignore`: the repository had none, so `.env` (created from
  `.env.example` as CONTRIBUTING.md instructs, and holding `POSTGRES_PASSWORD`)
  was not being ignored
- a PostgreSQL service in `ci-backend.yml`, since `@SpringBootTest` now needs a
  real database to load the context
- `GlobalExceptionHandler`, which is unrelated to the migration — happy to move
  it to a separate PR if you prefer

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [x] Infrastructure / CI / CD / Docker
- [ ] Other:

## Affected module(s)

- [x] backend
- [ ] frontend
- [ ] desktop
- [ ] mobile
- [x] infra (docker / CI / CD)

## How to test

1. Create your `.env` and start the database (the dev compose is the one that
   publishes port 5432):

   ```bash
   cp .env.example .env
   docker compose -f docker-compose.dev.yml up -d db
   ```

2. Run the build, taking the datasource from your own `.env`:

   ```bash
   cd backend
   set -a && . ../.env && set +a
   SPRING_DATASOURCE_URL="jdbc:postgresql://localhost:5432/${POSTGRES_DB}" \
   SPRING_DATASOURCE_USERNAME="${POSTGRES_USER}" \
   SPRING_DATASOURCE_PASSWORD="${POSTGRES_PASSWORD}" \
   ./mvnw clean verify
   ```

3. The log should show:

   ```
   Migrating schema "public" to version "1 - init schema"
   Successfully applied 1 migration to schema "public", now at version v1
   ```

4. Confirm the schema:

   ```bash
   docker exec -it calendar-db-dev \
     psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -c '\dt' -c '\dT'
   ```

   Expected: the six tables plus `flyway_schema_history`, and the
   `notification_type` type.

5. Re-running step 2 should report `Schema "public" is up to date. No migration
   necessary.`

## Checklist

- [x] I ran the tests locally and they passed
- [ ] I updated the documentation (README/CONTRIBUTING), if necessary
- [x] I did not leave any `console.log` / `System.out.println` / `print` debug statements
- [x] I followed the project's commit convention (Conventional Commits)
- [x] I reviewed my own diff before opening the PR
