### PR TITLE
feat: add BaseEntity and Configuration entity

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -69,6 +69,15 @@
 			<artifactId>spring-boot-starter-webmvc-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.aventrix.jnanoid</groupId>
+			<artifactId>jnanoid</artifactId>
+			<version>2.0.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/backend/src/main/java/br/com/calendar/common/BaseEntity.java
+++ b/backend/src/main/java/br/com/calendar/common/BaseEntity.java
@@ -1,0 +1,35 @@
+package br.com.calendar.common;
+
+import com.aventrix.jnanoid.jnanoid.NanoIdUtils;
+import jakarta.persistence.Column;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+@MappedSuperclass
+public abstract class BaseEntity {
+
+
+    @Id
+    private String id;
+
+    @Column(name = "created_at")
+    private Instant createdAt;
+
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (this.id == null) {
+            this.id = NanoIdUtils.randomNanoId();
+        }
+        this.createdAt = Instant.now();
+        this.updatedAt = Instant.now();
+    }
+
+}

--- a/backend/src/main/java/br/com/calendar/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/br/com/calendar/common/exception/GlobalExceptionHandler.java
@@ -1,9 +1,8 @@
-package br.com.calendar.handler;
+package br.com.calendar.common.exception;
 
 import org.jspecify.annotations.NonNull;
 import org.springframework.http.*;
 import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;

--- a/backend/src/main/java/br/com/calendar/configuration/Configuration.java
+++ b/backend/src/main/java/br/com/calendar/configuration/Configuration.java
@@ -1,0 +1,29 @@
+package br.com.calendar.configuration;
+
+import br.com.calendar.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@Table(name = "configuration")
+@AttributeOverride(name = "id", column = @Column(name = "user_id"))
+public class Configuration extends BaseEntity {
+
+    @Column(name = "user_id")
+    private String userId;
+
+    @Column(length = 20)
+    private String theme;
+
+    @Column(name = "time_format", length = 10)
+    private String timeFormat;
+
+    @Column(name = "week_start_day")
+    private String weekStartDay;
+
+    @Column(name = "default_view", length = 20)
+    private String defaultView;
+}


### PR DESCRIPTION
## Description

Adiciona a classe base `BaseEntity` (id, createdAt, updatedAt) para ser herdada pelas entidades JPA, e a entidade `Configuration`, que reutiliza o ID do usuário como chave primária. Também reorganiza `GlobalExceptionHandler` para a pasta `common/exception`.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Infrastructure / CI / CD / Docker
- [ ] Other:

## Affected module(s)

- [x] backend
- [ ] frontend
- [ ] desktop
- [ ] mobile
- [ ] infra (docker / CI / CD)

## How to test

<!-- Steps to reproduce/validate locally. -->

1. Rodar o backend (docker compose -f docker-compose.dev.yml up --build)
2. Verificar que a aplicação sobe sem erros de mapeamento JPA