### PR TITLE
fix: correct migration V1 schema (id types, timestamps, cascades)

### DIFF
--- a/backend/src/main/java/br/com/calendar/common/BaseEntity.java
+++ b/backend/src/main/java/br/com/calendar/common/BaseEntity.java
@@ -13,7 +13,6 @@ import java.time.Instant;
 @MappedSuperclass
 public abstract class BaseEntity {
 
-
     @Id
     private String id;
 

--- a/backend/src/main/java/br/com/calendar/configuration/Configuration.java
+++ b/backend/src/main/java/br/com/calendar/configuration/Configuration.java
@@ -12,9 +12,6 @@ import lombok.EqualsAndHashCode;
 @AttributeOverride(name = "id", column = @Column(name = "user_id"))
 public class Configuration extends BaseEntity {
 
-    @Column(name = "user_id")
-    private String userId;
-
     @Column(length = 20)
     private String theme;
 

--- a/backend/src/main/resources/db/migration/V1__init_schema.sql
+++ b/backend/src/main/resources/db/migration/V1__init_schema.sql
@@ -1,14 +1,16 @@
 -- V1 - create tables
+
 CREATE TYPE notification_type AS ENUM ('email', 'notificacao');
 
 
+-- `users` needs to come before `configuration/task/category` because of the foreign keys pointing to it.
 CREATE TABLE users
 (
-    id              char(21) PRIMARY KEY,
-    avatar          text,
+    id              varchar(21) PRIMARY KEY,
     name            varchar(200),
     email           varchar(200),
     email_confirmed boolean,
+    avatar          text,
     otp             varchar(8),
     otp_expiration  timestamp,
     password        varchar(100),
@@ -17,61 +19,70 @@ CREATE TABLE users
 );
 
 
-CREATE TABLE category
+CREATE TABLE configuration
 (
-    id         integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-    user_id    char(21) REFERENCES users (id),
-    color      varchar(6),
-    created_at timestamptz,
-    title      varchar
+    user_id        varchar(21) REFERENCES users (id) ON DELETE CASCADE,
+    theme          varchar,
+    time_format    varchar,
+    week_start_day varchar,
+    default_view   varchar,
+    created_at     timestamptz,
+    updated_at     timestamptz
 );
 
 
 CREATE TABLE task
 (
-    all_day         boolean,
-    id              integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-    user_id         char(21) REFERENCES users (id),
-    category_id     integer REFERENCES category (id),
-    timezone        text,
-    location        text,
+    id              varchar(21) PRIMARY KEY,
+    user_id         varchar(21) REFERENCES users (id) ON DELETE CASCADE,
+    category_id     varchar(21),
     title           varchar(255),
     description     text,
+    timezone        text,
+    location        text,
     status          varchar,
     starts_at       timestamptz,
     ends_at         timestamptz,
     repeat          integer,
-    repeat_interval varchar(15)
+    repeat_interval varchar(15),
+    all_day         boolean,
+    created_at      timestamptz,
+    updated_at      timestamptz
 );
 
 
-CREATE TABLE configuration
+CREATE TABLE category
 (
-    id             integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-    user_id        char(21) REFERENCES users (id),
-    theme          varchar,
-    time_format    varchar,
-    update_at      timestamptz,
-    week_start_day varchar,
-    created_at     timestamptz,
-    default_view   varchar
+    id         varchar(21) PRIMARY KEY,
+    user_id    varchar(21) REFERENCES users (id) ON DELETE CASCADE,
+    title      varchar,
+    color      varchar(6),
+    created_at timestamptz,
+    updated_at timestamptz
 );
+
+
+ALTER TABLE task
+    ADD CONSTRAINT fk_task_category FOREIGN KEY (category_id) REFERENCES category (id);
 
 
 CREATE TABLE notification
 (
-    id          integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-    user_id     char(21) REFERENCES users (id),
+    id          varchar(21) PRIMARY KEY,
+    user_id     varchar(21) REFERENCES users (id) ON DELETE CASCADE,
     time_before timestamptz,
     type        notification_type,
-    task_id     integer REFERENCES task (id),
-    read        boolean
+    task_id     varchar(21) REFERENCES task (id),
+    read        boolean,
+    created_at  timestamptz,
+    updated_at  timestamptz
 );
+
 
 CREATE TABLE log
 (
     id         integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-    user_id    char(21) REFERENCES users (id),
+    user_id    varchar(21) REFERENCES users (id),
     table_name text,
     table_id   text,
     type       varchar(32),

--- a/backend/src/main/resources/db/migration/V1__init_schema.sql
+++ b/backend/src/main/resources/db/migration/V1__init_schema.sql
@@ -21,7 +21,7 @@ CREATE TABLE users
 
 CREATE TABLE configuration
 (
-    user_id        varchar(21) REFERENCES users (id) ON DELETE CASCADE,
+    user_id        varchar(21) PRIMARY KEY REFERENCES users (id) ON DELETE CASCADE,
     theme          varchar,
     time_format    varchar,
     week_start_day varchar,


### PR DESCRIPTION
## Description
<!-- What does this PR do and why? -->
Fixes the initial database migration (`V1__init_schema.sql`), which had mismatches between the column types defined in SQL and what the Java entities (via `BaseEntity`) expected. This was causing the application to fail on startup (`SchemaManagementException`) when running the backend.

Main changes:
- Changed `char(21)` to `varchar(21)` for all ID columns (Nano ID), including `users.id` and the FKs referencing it
- Changed `integer GENERATED ALWAYS AS IDENTITY` to `varchar(21)` in `category.id`, `task.id`, `notification.id`, and `notification.task_id`, to keep consistency with the Nano ID pattern used elsewhere in the project (`log.id` was kept as `integer`, since that table is only queried directly in the database, without API exposure)
- Fixed typo `update_at` → `updated_at` in the `configuration` table
- Added missing `created_at`/`updated_at` columns to `task`, `category`, and `notification`, since these entities extend `BaseEntity` and Hibernate expects those columns
- Added `ON DELETE CASCADE` on `user_id` foreign keys (except in `log`, to preserve the audit trail even after a user is deleted)
- Resolved a merge conflict in `Configuration.java`: removed a duplicated `userId` field and restored the `@AttributeOverride` annotation, keeping the pattern of reusing the inherited `id` (from `BaseEntity`) as the reference to the user in 1-to-1 relations

## Type of change
- [ ] New feature
- [x] Bug fix
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Infrastructure / CI / CD / Docker
- [ ] Other:

## Affected module(s)
- [x] backend
- [ ] frontend
- [ ] desktop
- [ ] mobile
- [ ] infra (docker / CI / CD)

## How to test
<!-- Steps to reproduce/validate locally. -->
1. Reset the local database: `docker compose -f docker-compose.dev.yml down -v`
2. Start the backend: `docker compose -f docker-compose.dev.yml up --build`
3. Confirm the log shows `Started CalendarApplication` with no schema errors (`Schema validation`/`SchemaManagementException`)

## Checklist
- [ ] I ran the tests locally and they passed
- [ ] I updated the documentation (README/CONTRIBUTING), if necessary
- [x] I did not leave any `console.log` / `System.out.println` / `print` debug statements
- [x] I followed the project's commit convention (Conventional Commits)
- [x] I reviewed my own diff before opening the PR

## Related issue
Closes #