### PR TITLE
feat(backend): add the JPA entities for the V1 schema

### DIFF
--- a/backend/src/main/java/br/com/calendar/common/BaseEntity.java
+++ b/backend/src/main/java/br/com/calendar/common/BaseEntity.java
@@ -5,11 +5,15 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.PrePersist;
-import lombok.Data;
+import lombok.*;
 
 import java.time.Instant;
 
-@Data
+
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor
 @MappedSuperclass
 public abstract class BaseEntity {
 
@@ -30,5 +34,4 @@ public abstract class BaseEntity {
         this.createdAt = Instant.now();
         this.updatedAt = Instant.now();
     }
-
 }

--- a/backend/src/main/java/br/com/calendar/configuration/Configuration.java
+++ b/backend/src/main/java/br/com/calendar/configuration/Configuration.java
@@ -5,11 +5,15 @@ import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
-@Data
-@EqualsAndHashCode(callSuper = true)
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor
 @Entity
 @Table(name = "configuration")
 @AttributeOverride(name = "id", column = @Column(name = "user_id"))

--- a/backend/src/main/java/br/com/calendar/domain/Category.java
+++ b/backend/src/main/java/br/com/calendar/domain/Category.java
@@ -1,0 +1,32 @@
+package br.com.calendar.domain;
+
+import br.com.calendar.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor
+@Entity
+@Table(name = "category")
+public class Category extends BaseEntity {
+
+    @ToString.Exclude
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private String title;
+
+    @Column(length = 6)
+    private String color;
+}

--- a/backend/src/main/java/br/com/calendar/domain/Log.java
+++ b/backend/src/main/java/br/com/calendar/domain/Log.java
@@ -1,0 +1,59 @@
+package br.com.calendar.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.Instant;
+
+/**
+ * Não estende BaseEntity: o id é identity (integer) em vez de nanoid,
+ * e a tabela não tem updated_at.
+ */
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor
+@Entity
+@Table(name = "log")
+public class Log {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ToString.Exclude
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(name = "table_name")
+    private String tableName;
+
+    @Column(name = "table_id")
+    private String tableId;
+
+    @Column(length = 32)
+    private String type;
+
+    private String log;
+
+    @Column(name = "created_at")
+    private Instant createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = Instant.now();
+    }
+}

--- a/backend/src/main/java/br/com/calendar/domain/Notification.java
+++ b/backend/src/main/java/br/com/calendar/domain/Notification.java
@@ -1,0 +1,48 @@
+package br.com.calendar.domain;
+
+import br.com.calendar.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.hibernate.annotations.JdbcType;
+import org.hibernate.dialect.type.PostgreSQLEnumJdbcType;
+
+import java.time.Instant;
+
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor
+@Entity
+@Table(name = "notification")
+public class Notification extends BaseEntity {
+
+    @ToString.Exclude
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ToString.Exclude
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "task_id")
+    private Task task;
+
+    @Column(name = "time_before")
+    private Instant timeBefore;
+
+    @Enumerated(EnumType.STRING)
+    @JdbcType(PostgreSQLEnumJdbcType.class)
+    @Column(columnDefinition = "notification_type")
+    private NotificationType type;
+
+    private Boolean read;
+}

--- a/backend/src/main/java/br/com/calendar/domain/NotificationType.java
+++ b/backend/src/main/java/br/com/calendar/domain/NotificationType.java
@@ -1,0 +1,7 @@
+package br.com.calendar.domain;
+
+
+public enum NotificationType {
+    email,
+    notificacao
+}

--- a/backend/src/main/java/br/com/calendar/domain/Task.java
+++ b/backend/src/main/java/br/com/calendar/domain/Task.java
@@ -1,0 +1,59 @@
+package br.com.calendar.domain;
+
+import br.com.calendar.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.Instant;
+
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor
+@Entity
+@Table(name = "task")
+public class Task extends BaseEntity {
+
+    @ToString.Exclude
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ToString.Exclude
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
+
+    @Column(length = 255)
+    private String title;
+
+    private String description;
+
+    private String timezone;
+
+    private String location;
+
+    private String status;
+
+    @Column(name = "starts_at")
+    private Instant startsAt;
+
+    @Column(name = "ends_at")
+    private Instant endsAt;
+
+    private Integer repeat;
+
+    @Column(name = "repeat_interval", length = 15)
+    private String repeatInterval;
+
+    @Column(name = "all_day")
+    private Boolean allDay;
+}

--- a/backend/src/main/java/br/com/calendar/domain/User.java
+++ b/backend/src/main/java/br/com/calendar/domain/User.java
@@ -1,0 +1,43 @@
+package br.com.calendar.domain;
+
+import br.com.calendar.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor
+@Entity
+@Table(name = "users")
+public class User extends BaseEntity {
+
+    @Column(length = 200)
+    private String name;
+
+    @Column(length = 200)
+    private String email;
+
+    @Column(name = "email_confirmed")
+    private Boolean emailConfirmed;
+
+    private String avatar;
+
+    @ToString.Exclude
+    @Column(length = 8)
+    private String otp;
+
+    @Column(name = "otp_expiration")
+    private LocalDateTime otpExpiration;
+
+    @ToString.Exclude
+    @Column(length = 100)
+    private String password;
+}


### PR DESCRIPTION
## Description

Adds the JPA entities for the tables created by `V1__init_schema.sql`, which
had the schema but no mapping: `User`, `Task`, `Category`, `Notification` and
`Log`, in `br.com.calendar.domain`.

Two points worth reviewing:

- `Log` does not extend `BaseEntity`. Its primary key is an identity integer
  rather than a nanoid, and the table has no `updated_at`, so it declares its
  own `id` and `created_at`.
- `notification.type` maps to the native `notification_type` enum. It needs
  `@JdbcType(PostgreSQLEnumJdbcType.class)`, because Postgres rejects the
  varchar bind Hibernate uses by default. The constants of `NotificationType`
  are lowercase since Hibernate sends `name()` straight to the database, where
  the labels are `email` and `notificacao`.

`task.status` and `task.repeat_interval` are kept as `String`: the column type
is `varchar` and the accepted values are not defined anywhere yet. They can
become enums once that is decided.

The first commit replaces `@Data` with `@Getter`/`@Setter`/`@ToString` on
`BaseEntity` and `Configuration`. `@Data` generates `equals`/`hashCode` over
every field, which is unsafe on JPA entities: mutable fields change the hash
after persistence, and lazy proxies compare as different from the entity they
stand for.

## Type of change

- [x] New feature
- [ ] Bug fix
- [x] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Infrastructure / CI / CD / Docker
- [ ] Other:

## Affected module(s)

- [x] backend
- [ ] frontend
- [ ] desktop
- [ ] mobile
- [ ] infra (docker / CI / CD)

## How to test

1. `docker compose -f docker-compose.dev.yml up -d db`
2. `cd backend && SPRING_DATASOURCE_URL=jdbc:postgresql://localhost:5432/calendar SPRING_DATASOURCE_USERNAME=calendar SPRING_DATASOURCE_PASSWORD=calendar ./mvnw -B clean verify`
3. `contextLoads` boots the whole context, so Flyway applies V1 and
   `spring.jpa.hibernate.ddl-auto=validate` checks every entity against the
   schema. A wrong mapping fails the build.

## Checklist

- [x] I ran the tests locally and they passed
- [ ] I updated the documentation (README/CONTRIBUTING), if necessary
- [x] I did not leave any `console.log` / `System.out.println` / `print` debug statements
- [x] I followed the project's commit convention (Conventional Commits)
- [x] I reviewed my own diff before opening the PR

## Related issue

<!-- Note: the CI workflows trigger on `branches: [main, develop]`, but this
repository's integration branch is `development`, so none of them run on this
PR. Worth a separate one-line fix. -->
