### PR TITLE
feat(backend): add login and me endpoints

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -48,6 +48,27 @@
 			<artifactId>flyway-database-postgresql</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.12.6</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.12.6</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.12.6</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>

--- a/backend/src/main/java/br/com/calendar/auth/AuthController.java
+++ b/backend/src/main/java/br/com/calendar/auth/AuthController.java
@@ -1,0 +1,35 @@
+package br.com.calendar.auth;
+
+import br.com.calendar.auth.dto.AuthResponse;
+import br.com.calendar.auth.dto.LoginRequest;
+import br.com.calendar.user.dto.UserResponse;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class AuthController {
+
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/auth/login")
+    public ResponseEntity<AuthResponse> login(@Valid @RequestBody LoginRequest request) {
+        return ResponseEntity.ok(authService.login(request));
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<UserResponse> me() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = authentication.getName();
+        return ResponseEntity.ok(authService.me(email));
+    }
+}

--- a/backend/src/main/java/br/com/calendar/auth/AuthService.java
+++ b/backend/src/main/java/br/com/calendar/auth/AuthService.java
@@ -1,0 +1,43 @@
+package br.com.calendar.auth;
+
+import br.com.calendar.auth.dto.AuthResponse;
+import br.com.calendar.auth.dto.LoginRequest;
+import br.com.calendar.domain.User;
+import br.com.calendar.user.UserRepository;
+import br.com.calendar.user.dto.UserResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtUtil jwtUtil;
+
+    public AuthService(UserRepository userRepository, PasswordEncoder passwordEncoder, JwtUtil jwtUtil) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtUtil = jwtUtil;
+    }
+
+    public AuthResponse login(LoginRequest request) {
+        User user = userRepository.findByEmail(request.email())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid email or password"));
+
+        if (!passwordEncoder.matches(request.password(), user.getPassword())) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid email or password");
+        }
+
+        String token = jwtUtil.generateToken(user.getEmail());
+        return new AuthResponse(token, "Bearer", jwtUtil.getExpirationMs() / 1000);
+    }
+
+    public UserResponse me(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+        return new UserResponse(user.getId(), user.getName(), user.getEmail());
+    }
+}

--- a/backend/src/main/java/br/com/calendar/auth/JwtFilter.java
+++ b/backend/src/main/java/br/com/calendar/auth/JwtFilter.java
@@ -1,0 +1,55 @@
+package br.com.calendar.auth;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+public class JwtFilter extends OncePerRequestFilter {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtUtil jwtUtil;
+
+    public JwtFilter(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String header = request.getHeader("Authorization");
+        if (header != null && header.startsWith(BEARER_PREFIX)) {
+            String token = header.substring(BEARER_PREFIX.length());
+            try {
+                String email = jwtUtil.extractEmail(token);
+                if (email != null && !jwtUtil.isExpired(token)
+                        && SecurityContextHolder.getContext().getAuthentication() == null) {
+
+                    var userDetails = org.springframework.security.core.userdetails.User
+                            .withUsername(email)
+                            .password("")
+                            .authorities(List.of())
+                            .build();
+
+                    UsernamePasswordAuthenticationToken authentication =
+                            new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
+            } catch (Exception ex) {
+                SecurityContextHolder.clearContext();
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/backend/src/main/java/br/com/calendar/auth/JwtUtil.java
+++ b/backend/src/main/java/br/com/calendar/auth/JwtUtil.java
@@ -1,0 +1,59 @@
+package br.com.calendar.auth;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+
+    private final SecretKey key;
+    private final long expirationMs;
+
+    public JwtUtil(@Value("${jwt.secret}") String secret,
+                   @Value("${jwt.expiration-ms}") long expirationMs) {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.expirationMs = expirationMs;
+    }
+
+    public String generateToken(String email) {
+        Date now = new Date();
+        return Jwts.builder()
+                .subject(email)
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + expirationMs))
+                .signWith(key)
+                .compact();
+    }
+
+    public String extractEmail(String token) {
+        return parseClaims(token).getSubject();
+    }
+
+    public boolean isExpired(String token) {
+        try {
+            return parseClaims(token).getExpiration().before(new Date());
+        } catch (ExpiredJwtException ex) {
+            return true;
+        }
+    }
+
+    public long getExpirationMs() {
+        return expirationMs;
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/backend/src/main/java/br/com/calendar/auth/dto/AuthResponse.java
+++ b/backend/src/main/java/br/com/calendar/auth/dto/AuthResponse.java
@@ -1,0 +1,4 @@
+package br.com.calendar.auth.dto;
+
+public record AuthResponse(String accessToken, String tokenType, long expiresIn) {
+}

--- a/backend/src/main/java/br/com/calendar/auth/dto/LoginRequest.java
+++ b/backend/src/main/java/br/com/calendar/auth/dto/LoginRequest.java
@@ -1,0 +1,13 @@
+package br.com.calendar.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank(message = "Email is required")
+        @Email(message = "Email must be a valid address")
+        String email,
+
+        @NotBlank(message = "Password is required")
+        String password) {
+}

--- a/backend/src/main/java/br/com/calendar/config/PasswordConfig.java
+++ b/backend/src/main/java/br/com/calendar/config/PasswordConfig.java
@@ -1,0 +1,15 @@
+package br.com.calendar.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/backend/src/main/java/br/com/calendar/config/SecurityConfig.java
+++ b/backend/src/main/java/br/com/calendar/config/SecurityConfig.java
@@ -1,0 +1,35 @@
+package br.com.calendar.config;
+
+import br.com.calendar.auth.JwtFilter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final JwtFilter jwtFilter;
+
+    public SecurityConfig(JwtFilter jwtFilter) {
+        this.jwtFilter = jwtFilter;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .logout(logout -> logout.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/auth/login", "/health").permitAll()
+                        .anyRequest().authenticated())
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/backend/src/main/java/br/com/calendar/user/UserRepository.java
+++ b/backend/src/main/java/br/com/calendar/user/UserRepository.java
@@ -1,0 +1,11 @@
+package br.com.calendar.user;
+
+import br.com.calendar.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, String> {
+
+    Optional<User> findByEmail(String email);
+}

--- a/backend/src/main/java/br/com/calendar/user/dto/UserResponse.java
+++ b/backend/src/main/java/br/com/calendar/user/dto/UserResponse.java
@@ -1,0 +1,4 @@
+package br.com.calendar.user.dto;
+
+public record UserResponse(String id, String name, String email) {
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -8,3 +8,6 @@ spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.show-sql=true
 
 spring.flyway.locations=classpath:db/migration
+
+jwt.secret=${JWT_SECRET:dev-only-secret-change-in-production-0123456789abcdef}
+jwt.expiration-ms=86400000

--- a/backend/src/test/java/br/com/calendar/auth/AuthServiceTest.java
+++ b/backend/src/test/java/br/com/calendar/auth/AuthServiceTest.java
@@ -1,0 +1,94 @@
+package br.com.calendar.auth;
+
+import br.com.calendar.auth.dto.AuthResponse;
+import br.com.calendar.auth.dto.LoginRequest;
+import br.com.calendar.domain.User;
+import br.com.calendar.user.UserRepository;
+import br.com.calendar.user.dto.UserResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    private AuthService authService;
+
+    @BeforeEach
+    void setUp() {
+        authService = new AuthService(userRepository, passwordEncoder, jwtUtil);
+    }
+
+    @Test
+    void loginWithValidCredentialsReturnsToken() {
+        User user = new User();
+        user.setEmail("test@example.com");
+        user.setPassword("hashed-password");
+
+        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches("plain-password", "hashed-password")).thenReturn(true);
+        when(jwtUtil.generateToken("test@example.com")).thenReturn("jwt-token");
+        when(jwtUtil.getExpirationMs()).thenReturn(86400000L);
+
+        AuthResponse response = authService.login(new LoginRequest("test@example.com", "plain-password"));
+
+        assertEquals("jwt-token", response.accessToken());
+        assertEquals("Bearer", response.tokenType());
+    }
+
+    @Test
+    void loginWithWrongPasswordThrows() {
+        User user = new User();
+        user.setEmail("test@example.com");
+        user.setPassword("hashed-password");
+
+        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches("wrong-password", "hashed-password")).thenReturn(false);
+
+        assertThrows(ResponseStatusException.class,
+                () -> authService.login(new LoginRequest("test@example.com", "wrong-password")));
+    }
+
+    @Test
+    void loginWithUnknownEmailThrows() {
+        when(userRepository.findByEmail("unknown@example.com")).thenReturn(Optional.empty());
+
+        assertThrows(ResponseStatusException.class,
+                () -> authService.login(new LoginRequest("unknown@example.com", "any-password")));
+    }
+
+    @Test
+    void meReturnsUserData() {
+        User user = new User();
+        user.setId("usr_abc123");
+        user.setName("Danillo");
+        user.setEmail("test@example.com");
+
+        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+
+        UserResponse response = authService.me("test@example.com");
+
+        assertEquals("usr_abc123", response.id());
+        assertEquals("Danillo", response.name());
+        assertEquals("test@example.com", response.email());
+    }
+}

--- a/backend/src/test/java/br/com/calendar/auth/JwtUtilTest.java
+++ b/backend/src/test/java/br/com/calendar/auth/JwtUtilTest.java
@@ -1,0 +1,48 @@
+package br.com.calendar.auth;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JwtUtilTest {
+
+    private static final String SECRET = "dev-only-secret-change-in-production-0123456789abcdef";
+
+    private JwtUtil jwtUtil;
+
+    @BeforeEach
+    void setUp() {
+        jwtUtil = new JwtUtil(SECRET, 86400000L);
+    }
+
+    @Test
+    void generateTokenAndExtractEmail() {
+        String token = jwtUtil.generateToken("test@example.com");
+
+        assertEquals("test@example.com", jwtUtil.extractEmail(token));
+    }
+
+    @Test
+    void tokenIsNotExpired() {
+        String token = jwtUtil.generateToken("test@example.com");
+
+        assertFalse(jwtUtil.isExpired(token));
+    }
+
+    @Test
+    void expiredTokenIsDetected() {
+        JwtUtil shortLivedJwt = new JwtUtil(SECRET, -1000L);
+        String token = shortLivedJwt.generateToken("test@example.com");
+
+        assertTrue(shortLivedJwt.isExpired(token));
+    }
+
+    @Test
+    void invalidTokenThrows() {
+        assertThrows(Exception.class, () -> jwtUtil.extractEmail("invalid.token.here"));
+    }
+}


### PR DESCRIPTION
## Description

Adds stateless authentication to the backend: a JWT login endpoint and a ''me'' endpoint that returns the authenticated user.

## Type of change

- [x] New feature

## Affected module(s)

- [x] backend

## How to test

1. Start the backend with the Postgres datasource env vars.
2. \POST /auth/login\ with a valid user email/password returns an \ccessToken\.
3. \GET /me\ with \Authorization: Bearer <token>\ returns user id/name/email.
4. \mvnw verify\ passes locally (9 tests).

## Checklist

- [x] I ran the tests locally and they passed
- [ ] I updated the documentation (README/CONTRIBUTING), if necessary
- [x] I did not leave any debug statements
- [x] I followed the project's commit convention (Conventional Commits)
- [x] I reviewed my own diff before opening the PR

Closes #27