### PR TITLE
feat(backend): add logout endpoint with token blacklist

### DIFF
--- a/backend/src/main/java/br/com/calendar/auth/AuthController.java
+++ b/backend/src/main/java/br/com/calendar/auth/AuthController.java
@@ -4,6 +4,7 @@ import br.com.calendar.auth.dto.AuthResponse;
 import br.com.calendar.auth.dto.LoginRequest;
 import br.com.calendar.auth.dto.SignupRequest;
 import br.com.calendar.user.dto.UserSummaryDTO;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -42,5 +43,17 @@ public class AuthController {
         }
         String userId = authentication.getName();
         return ResponseEntity.ok(authService.me(userId));
+    }
+
+    @PostMapping("/auth/logout")
+    public ResponseEntity<Void> logout(HttpServletRequest request) {
+        String header = request.getHeader("Authorization");
+        String token = null;
+        if (header != null && header.startsWith("Bearer ")) {
+            token = header.substring(7);
+        }
+
+        authService.logout(token);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/br/com/calendar/auth/AuthService.java
+++ b/backend/src/main/java/br/com/calendar/auth/AuthService.java
@@ -62,6 +62,14 @@ public class AuthService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Token is required");
         }
 
+        // valida se é um JWT de verdade antes de colocar na blacklist.
+        // se for uma string qualquer, o jwtUtil lança exceção → 400 em vez de 500.
+        try {
+            jwtUtil.getExpirationDate(token);
+        } catch (Exception e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid token");
+        }
+
         tokenBlacklist.cleanExpired();
         tokenBlacklist.revoke(token);
     }

--- a/backend/src/main/java/br/com/calendar/auth/AuthService.java
+++ b/backend/src/main/java/br/com/calendar/auth/AuthService.java
@@ -21,13 +21,15 @@ public class AuthService {
     private final UserService userService;
     private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
+    private final TokenBlacklist tokenBlacklist;
 
     public AuthService(UserRepository userRepository, UserService userService,
-                       PasswordEncoder passwordEncoder, JwtUtil jwtUtil) {
+                       PasswordEncoder passwordEncoder, JwtUtil jwtUtil, TokenBlacklist tokenBlacklist) {
         this.userRepository = userRepository;
         this.userService = userService;
         this.passwordEncoder = passwordEncoder;
         this.jwtUtil = jwtUtil;
+        this.tokenBlacklist = tokenBlacklist;
     }
 
     public AuthResponse signup(SignupRequest request) {
@@ -53,5 +55,14 @@ public class AuthService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
         return new UserSummaryDTO(user.getId(), user.getName(), user.getEmail());
+    }
+
+    public void logout(String token) {
+        if (token == null || token.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Token is required");
+        }
+
+        tokenBlacklist.cleanExpired();
+        tokenBlacklist.revoke(token);
     }
 }

--- a/backend/src/main/java/br/com/calendar/auth/JwtFilter.java
+++ b/backend/src/main/java/br/com/calendar/auth/JwtFilter.java
@@ -18,9 +18,11 @@ public class JwtFilter extends OncePerRequestFilter {
     private static final String BEARER_PREFIX = "Bearer ";
 
     private final JwtUtil jwtUtil;
+    private final TokenBlacklist tokenBlacklist;
 
-    public JwtFilter(JwtUtil jwtUtil) {
+    public JwtFilter(JwtUtil jwtUtil, TokenBlacklist tokenBlacklist) {
         this.jwtUtil = jwtUtil;
+        this.tokenBlacklist = tokenBlacklist;
     }
 
     @Override
@@ -32,7 +34,7 @@ public class JwtFilter extends OncePerRequestFilter {
             String token = header.substring(BEARER_PREFIX.length());
             try {
                 String userId = jwtUtil.extractUserId(token);
-                if (userId != null && !jwtUtil.isExpired(token)
+                if (userId != null && !jwtUtil.isExpired(token) && !tokenBlacklist.isRevoked(token)
                         && SecurityContextHolder.getContext().getAuthentication() == null) {
 
                     var userDetails = org.springframework.security.core.userdetails.User

--- a/backend/src/main/java/br/com/calendar/auth/JwtUtil.java
+++ b/backend/src/main/java/br/com/calendar/auth/JwtUtil.java
@@ -37,6 +37,10 @@ public class JwtUtil {
         return parseClaims(token).getSubject();
     }
 
+    public Date getExpirationDate(String token) {
+        return parseClaims(token).getExpiration();
+    }
+
     public boolean isExpired(String token) {
         try {
             return parseClaims(token).getExpiration().before(new Date());

--- a/backend/src/main/java/br/com/calendar/auth/TokenBlacklist.java
+++ b/backend/src/main/java/br/com/calendar/auth/TokenBlacklist.java
@@ -1,5 +1,7 @@
 package br.com.calendar.auth;
 
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.time.Instant;
@@ -8,8 +10,12 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Component
+@EnableScheduling
 public class TokenBlacklist {
 
+    // WARNING: isso é in-memory. Se rodar mais de uma instância do backend
+    // (load balancer, etc.), um logout numa instância não invalida o token
+    // nas outras. Trocar por Redis/DB quando precisar de multi-instância.
     private final Map<String, Instant> revokedTokens = new ConcurrentHashMap<>();
     private final JwtUtil jwtUtil;
 
@@ -26,6 +32,9 @@ public class TokenBlacklist {
         return revokedTokens.containsKey(token);
     }
 
+    // roda a cada hora pra limpar tokens expirados da memória,
+    // sem depender de alguém fazer logout pra triggerar a limpeza.
+    @Scheduled(fixedRate = 3600000)
     public void cleanExpired() {
         Instant now = Instant.now();
         revokedTokens.entrySet().removeIf(entry -> entry.getValue().isBefore(now));

--- a/backend/src/main/java/br/com/calendar/auth/TokenBlacklist.java
+++ b/backend/src/main/java/br/com/calendar/auth/TokenBlacklist.java
@@ -1,0 +1,33 @@
+package br.com.calendar.auth;
+
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class TokenBlacklist {
+
+    private final Map<String, Instant> revokedTokens = new ConcurrentHashMap<>();
+    private final JwtUtil jwtUtil;
+
+    public TokenBlacklist(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    public void revoke(String token) {
+        Date expiration = jwtUtil.getExpirationDate(token);
+        revokedTokens.put(token, expiration.toInstant());
+    }
+
+    public boolean isRevoked(String token) {
+        return revokedTokens.containsKey(token);
+    }
+
+    public void cleanExpired() {
+        Instant now = Instant.now();
+        revokedTokens.entrySet().removeIf(entry -> entry.getValue().isBefore(now));
+    }
+}

--- a/backend/src/test/java/br/com/calendar/auth/AuthServiceTest.java
+++ b/backend/src/test/java/br/com/calendar/auth/AuthServiceTest.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -42,11 +43,14 @@ class AuthServiceTest {
     @Mock
     private JwtUtil jwtUtil;
 
+    @Mock
+    private TokenBlacklist tokenBlacklist;
+
     private AuthService authService;
 
     @BeforeEach
     void setUp() {
-        authService = new AuthService(userRepository, userService, passwordEncoder, jwtUtil);
+        authService = new AuthService(userRepository, userService, passwordEncoder, jwtUtil, tokenBlacklist);
     }
 
     @Test
@@ -119,5 +123,17 @@ class AuthServiceTest {
         assertEquals(USER_ID, response.id());
         assertEquals("Danillo", response.name());
         assertEquals("test@example.com", response.email());
+    }
+
+    @Test
+    void logoutRevokesToken() {
+        authService.logout("jwt-token");
+
+        verify(tokenBlacklist).revoke("jwt-token");
+    }
+
+    @Test
+    void logoutWithBlankTokenThrows() {
+        assertThrows(ResponseStatusException.class, () -> authService.logout(" "));
     }
 }

--- a/backend/src/test/java/br/com/calendar/auth/AuthServiceTest.java
+++ b/backend/src/test/java/br/com/calendar/auth/AuthServiceTest.java
@@ -136,4 +136,12 @@ class AuthServiceTest {
     void logoutWithBlankTokenThrows() {
         assertThrows(ResponseStatusException.class, () -> authService.logout(" "));
     }
+
+    @Test
+    void logoutWithMalformedTokenThrows() {
+        when(jwtUtil.getExpirationDate("not-a-real-jwt"))
+                .thenThrow(new io.jsonwebtoken.MalformedJwtException("Invalid JWT"));
+
+        assertThrows(ResponseStatusException.class, () -> authService.logout("not-a-real-jwt"));
+    }
 }

--- a/backend/src/test/java/br/com/calendar/auth/TokenBlacklistTest.java
+++ b/backend/src/test/java/br/com/calendar/auth/TokenBlacklistTest.java
@@ -1,0 +1,66 @@
+package br.com.calendar.auth;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TokenBlacklistTest {
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    private TokenBlacklist tokenBlacklist;
+
+    @BeforeEach
+    void setUp() {
+        tokenBlacklist = new TokenBlacklist(jwtUtil);
+    }
+
+    @Test
+    void revokedTokenIsBlacklisted() {
+        String token = "abc123";
+        when(jwtUtil.getExpirationDate(token)).thenReturn(Date.from(java.time.Instant.now().plusSeconds(3600)));
+
+        tokenBlacklist.revoke(token);
+
+        assertTrue(tokenBlacklist.isRevoked(token));
+    }
+
+    @Test
+    void tokenNotRevokedIsNotBlacklisted() {
+        String token = "other-token";
+        when(jwtUtil.getExpirationDate(token)).thenReturn(Date.from(java.time.Instant.now().plusSeconds(3600)));
+
+        tokenBlacklist.revoke(token);
+
+        assertFalse(tokenBlacklist.isRevoked("never-revoked"));
+    }
+
+    @Test
+    void cleanExpiredRemovesOnlyExpiredTokens() {
+        String expired = "expired-token";
+        String valid = "valid-token";
+
+        when(jwtUtil.getExpirationDate(expired))
+                .thenReturn(Date.from(java.time.Instant.now().minusSeconds(3600)));
+        when(jwtUtil.getExpirationDate(valid))
+                .thenReturn(Date.from(java.time.Instant.now().plusSeconds(3600)));
+
+        tokenBlacklist.revoke(expired);
+        tokenBlacklist.revoke(valid);
+
+        tokenBlacklist.cleanExpired();
+
+        assertFalse(tokenBlacklist.isRevoked(expired));
+        assertTrue(tokenBlacklist.isRevoked(valid));
+    }
+}


### PR DESCRIPTION
## Description

Adds the Logout endpoint from issue #27 (login/me already merged in #46). POST /auth/logout returns 204 and revokes the presented JWT through an in-memory token blacklist. The JwtFilter now refuses any blacklisted token, so a logged-out token stops working immediately even if it has not expired yet.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Infrastructure / CI / CD / Docker
- [ ] Other:

## Affected module(s)

- [x] backend
- [ ] frontend
- [ ] desktop
- [ ] mobile
- [ ] infra (docker / CI / CD)

## How to test

1. Run unit tests: ./mvnw test (AuthServiceTest, JwtUtilTest, TokenBlacklistTest - 14 passing).
2. Start Postgres and set SPRING_DATASOURCE_* env vars, then run the app.
3. POST /auth/login -> capture the token; GET /me with it -> 200.
4. POST /auth/logout with the Bearer token -> 204.
5. GET /me with the same token -> 401 (token revoked).

## Checklist

- [x] I ran the tests locally and they passed (unit tests)
- [ ] I updated the documentation (README/CONTRIBUTING), if necessary
- [x] I did not leave any console.log / System.out.println / print debug statements
- [x] I followed the project's commit convention (Conventional Commits)
- [x] I reviewed my own diff before opening the PR

## Related issue

Closes #27