### PR TITLE
build(infra): remove exposed db port in prod and restore datasource comment

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,5 +1,9 @@
 spring.application.name=calendar
 
+# The datasource comes from SPRING_DATASOURCE_URL / _USERNAME / _PASSWORD in the
+# environment. Spring Boot binds those variables on its own, so no database
+# value needs to be versioned here. See docker-compose.yml and ci-backend.yml.
+
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.show-sql=true
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,8 +48,6 @@ services:
   db:
     image: postgres:16-alpine
     container_name: calendar-db
-    ports:
-      - "${DB_PORT}:5432"
     restart: unless-stopped
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-calendar}


### PR DESCRIPTION
Addresses pending review comments from PR #52.

1. docker-compose.yml: Removed the db port mapping from the production compose. The backend connects to db over the internal calendar-net network, so exposing port 5432 is unnecessary and a potential security risk. Port is still exposed in docker-compose.dev.yml for local debugging.

2. application.properties: Restored the explanatory comment that documents the datasource configuration decision - values come from environment variables via docker-compose, not hardcoded in this file.

Closes review comments from #52