### PR TITLE
fix(common): add @PreUpdate to BaseEntity to keep updatedAt current

### DIFF
--- a/backend/src/main/java/br/com/calendar/common/BaseEntity.java
+++ b/backend/src/main/java/br/com/calendar/common/BaseEntity.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import lombok.*;
 
 import java.time.Instant;
@@ -31,6 +32,11 @@ public abstract class BaseEntity {
             this.id = NanoIdUtils.randomNanoId();
         }
         this.createdAt = Instant.now();
+        this.updatedAt = Instant.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
         this.updatedAt = Instant.now();
     }
 }


### PR DESCRIPTION
## Description
`updatedAt` in `BaseEntity` was only being set inside the `@PrePersist` method, so it got a value on creation but never changed again on updates. Added a `@PreUpdate` method to keep it current whenever an entity is modified.

Addresses a review comment left on commit e002c6a.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Infrastructure / CI / CD / Docker
- [ ] Other:

## Affected module(s)
- [x] backend
- [ ] frontend
- [ ] desktop
- [ ] mobile
- [ ] infra (docker / CI / CD)

## How to test
Run unit tests: `./mvnw test` (10 passing).
Any entity extending `BaseEntity` will now have `updatedAt` refreshed automatically on every update, not just on creation.

## Checklist
- [x] I ran the tests locally and they passed (unit tests)
- [ ] I updated the documentation (README/CONTRIBUTING), if necessary
- [x] I did not leave any console.log / System.out.println / print debug statements
- [x] I followed the project's commit convention (Conventional Commits)
- [x] I reviewed my own diff before opening the PR

## Related issue
N/A — addresses review comment on commit e002c6a