### PR TITLE
feat(auth): add forgot password endpoint

### DIFF
--- a/backend/src/main/java/br/com/calendar/auth/AuthController.java
+++ b/backend/src/main/java/br/com/calendar/auth/AuthController.java
@@ -1,8 +1,10 @@
 package br.com.calendar.auth;
 
 import br.com.calendar.auth.dto.AuthResponse;
+import br.com.calendar.auth.dto.ForgotPasswordRequest;
 import br.com.calendar.auth.dto.LoginRequest;
 import br.com.calendar.auth.dto.SignupRequest;
+import br.com.calendar.common.dto.MessageResponse;
 import br.com.calendar.user.dto.UserSummaryDTO;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
@@ -32,6 +34,11 @@ public class AuthController {
     @PostMapping("/auth/login")
     public ResponseEntity<AuthResponse> login(@Valid @RequestBody LoginRequest request) {
         return ResponseEntity.ok(authService.login(request));
+    }
+
+    @PostMapping("/auth/forgot-password")
+    public ResponseEntity<MessageResponse> requestPasswordReset(@Valid @RequestBody ForgotPasswordRequest request) {
+        return ResponseEntity.ok(authService.requestPasswordReset(request));
     }
 
     @GetMapping("/me")

--- a/backend/src/main/java/br/com/calendar/auth/AuthController.java
+++ b/backend/src/main/java/br/com/calendar/auth/AuthController.java
@@ -40,7 +40,7 @@ public class AuthController {
         return ResponseEntity.ok(authService.login(request));
     }
 
-    @Operation(summary = "Request password reset)
+    @Operation(summary = "Request password reset")
     @PostMapping("/auth/forgot-password")
     public ResponseEntity<MessageResponse> requestPasswordReset(@Valid @RequestBody ForgotPasswordRequest request) {
         return ResponseEntity.ok(authService.requestPasswordReset(request));

--- a/backend/src/main/java/br/com/calendar/auth/AuthService.java
+++ b/backend/src/main/java/br/com/calendar/auth/AuthService.java
@@ -1,19 +1,24 @@
 package br.com.calendar.auth;
 
 import br.com.calendar.auth.dto.AuthResponse;
+import br.com.calendar.auth.dto.ForgotPasswordRequest;
 import br.com.calendar.auth.dto.LoginRequest;
 import br.com.calendar.auth.dto.SignupRequest;
+import br.com.calendar.common.dto.MessageResponse;
 import br.com.calendar.user.User;
 import br.com.calendar.user.UserRepository;
 import br.com.calendar.user.UserService;
 import br.com.calendar.user.dto.CreateUserDTO;
+import br.com.calendar.user.dto.OtpResponseDTO;
 import br.com.calendar.user.dto.UserResponseDTO;
 import br.com.calendar.user.dto.UserSummaryDTO;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
+@Slf4j
 @Service
 public class AuthService {
 
@@ -47,6 +52,20 @@ public class AuthService {
 
         String token = jwtUtil.generateToken(user.getId());
         return new AuthResponse(token, "Bearer", jwtUtil.getExpirationMs() / 1000);
+    }
+
+    public MessageResponse requestPasswordReset(ForgotPasswordRequest request) {
+        userRepository.findByEmail(request.email())
+                .ifPresent(
+                        user -> {
+                            OtpResponseDTO otpResponseDTO = userService.generateEmailConfirmationOtp(user.getId());
+
+                            // Email added to the log message for identification during the test.
+                            log.info("Generated OTP for email: {} - Code: {}", user.getEmail(), otpResponseDTO.otp());
+                }
+        );
+
+        return new MessageResponse("If the email is registered, password reset instructions will be sent.");
     }
 
     public UserSummaryDTO me(String userId) {

--- a/backend/src/main/java/br/com/calendar/auth/dto/ForgotPasswordRequest.java
+++ b/backend/src/main/java/br/com/calendar/auth/dto/ForgotPasswordRequest.java
@@ -1,0 +1,11 @@
+package br.com.calendar.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record ForgotPasswordRequest(
+        @NotBlank(message = "Email is required")
+        @Email(message = "Email must be a valid address")
+        String email
+) {
+}

--- a/backend/src/main/java/br/com/calendar/common/dto/MessageResponse.java
+++ b/backend/src/main/java/br/com/calendar/common/dto/MessageResponse.java
@@ -1,0 +1,6 @@
+package br.com.calendar.common.dto;
+
+public record MessageResponse(
+        String message
+) {
+}

--- a/backend/src/main/java/br/com/calendar/config/SecurityConfig.java
+++ b/backend/src/main/java/br/com/calendar/config/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
                         .authenticationEntryPoint((request, response, authException) ->
                                 response.sendError(401, "Unauthorized")))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/login", "/auth/signup", "/health").permitAll()
+                        .requestMatchers("/auth/login", "/auth/signup", "/auth/forgot-password", "/health").permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/backend/src/test/java/br/com/calendar/auth/AuthServiceTest.java
+++ b/backend/src/test/java/br/com/calendar/auth/AuthServiceTest.java
@@ -1,12 +1,15 @@
 package br.com.calendar.auth;
 
 import br.com.calendar.auth.dto.AuthResponse;
+import br.com.calendar.auth.dto.ForgotPasswordRequest;
 import br.com.calendar.auth.dto.LoginRequest;
 import br.com.calendar.auth.dto.SignupRequest;
+import br.com.calendar.common.dto.MessageResponse;
 import br.com.calendar.user.User;
 import br.com.calendar.user.UserRepository;
 import br.com.calendar.user.UserService;
 import br.com.calendar.user.dto.CreateUserDTO;
+import br.com.calendar.user.dto.OtpResponseDTO;
 import br.com.calendar.user.dto.UserResponseDTO;
 import br.com.calendar.user.dto.UserSummaryDTO;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,12 +20,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -81,6 +85,36 @@ class AuthServiceTest {
 
         assertEquals("jwt-token", response.accessToken());
         assertEquals("Bearer", response.tokenType());
+    }
+
+    @Test
+    void requestPasswordResetWithValidEmailGeneratesOtp() {
+        User user = new User();
+        user.setId(USER_ID);
+        user.setEmail("test@example.com");
+        user.setPassword("hashed-password");
+
+        when(userRepository.findByEmail(any(String.class))).thenReturn(Optional.of(user));
+
+        SecureRandom random = new SecureRandom();
+        when(userService.generateEmailConfirmationOtp(any(String.class)))
+                .thenReturn(
+                        new OtpResponseDTO(String.format("%06d", random.nextInt(1_000_000)))
+                );
+
+        MessageResponse messageResponse = authService.requestPasswordReset(new ForgotPasswordRequest("test@example.com"));
+
+        assertEquals("If the email is registered, password reset instructions will be sent.", messageResponse.message());
+        verify(userService).generateEmailConfirmationOtp(user.getId());
+    }
+
+    @Test
+    void requestPasswordResetWithNonExistingEmailReturnsDefaultMessage() {
+        when(userRepository.findByEmail(any(String.class))).thenReturn(Optional.empty());
+
+        MessageResponse messageResponse = authService.requestPasswordReset(new ForgotPasswordRequest("test@example.com"));
+
+        assertEquals("If the email is registered, password reset instructions will be sent.", messageResponse.message());
     }
 
     @Test


### PR DESCRIPTION
## Description

Implements the password reset request endpoint using OTP.

The endpoint:
- accepts and validates the user's email
- generates and stores an OTP for existing users
- logs the generated OTP for development while SMTP is not configured
- returns a generic success response regardless of whether the email exists
- allows unauthenticated access to the forgot password endpoint
- adds request and generic message response DTOs for the new flow
- adds unit tests for existing and non-existing email scenarios

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Infrastructure / CI / CD / Docker
- [ ] Other:

## Affected module(s)

- [x] backend
- [ ] frontend
- [ ] desktop
- [ ] mobile
- [ ] infra (docker / CI / CD)

## How to test

1. Run the backend unit tests.
2. Send a `POST` request to `/auth/forgot-password` with a valid existing email.
3. Verify that:
   - the endpoint is accessible without authentication
   - an OTP is generated for an existing user
   - the OTP is logged for development
   - existing and non-existing emails return the same generic success response
   - invalid or blank emails return a validation error

## Checklist

- [x] I ran the tests locally and they passed
- [ ] I updated the documentation (README/CONTRIBUTING), if necessary
- [x] I did not leave any `console.log` / `System.out.println` / `print` debug statements
- [x] I followed the project's commit convention (Conventional Commits)
- [x] I reviewed my own diff before opening the PR

## Related issue

Closes #38