### PR TITLE
feat(backend): add OTP verification endpoint for password reset

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -2,12 +2,12 @@ name: CI - Backend
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, development]
     paths:
       - "backend/**"
       - ".github/workflows/ci-backend.yml"
   pull_request:
-    branches: [main, develop]
+    branches: [main, development]
     paths:
       - "backend/**"
       - ".github/workflows/ci-backend.yml"

--- a/.github/workflows/ci-desktop.yml
+++ b/.github/workflows/ci-desktop.yml
@@ -2,12 +2,12 @@ name: CI - Desktop
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, development]
     paths:
       - "desktop/**"
       - ".github/workflows/ci-desktop.yml"
   pull_request:
-    branches: [main, develop]
+    branches: [main, development]
     paths:
       - "desktop/**"
       - ".github/workflows/ci-desktop.yml"

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -2,12 +2,12 @@ name: CI - Frontend
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, development]
     paths:
       - "frontend/**"
       - ".github/workflows/ci-frontend.yml"
   pull_request:
-    branches: [main, develop]
+    branches: [main, development]
     paths:
       - "frontend/**"
       - ".github/workflows/ci-frontend.yml"

--- a/.github/workflows/ci-mobile.yml
+++ b/.github/workflows/ci-mobile.yml
@@ -2,12 +2,12 @@ name: CI - Mobile
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, development]
     paths:
       - "mobile/**"
       - ".github/workflows/ci-mobile.yml"
   pull_request:
-    branches: [main, develop]
+    branches: [main, development]
     paths:
       - "mobile/**"
       - ".github/workflows/ci-mobile.yml"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, development]
   pull_request:
-    branches: [main, develop]
+    branches: [main, development]
   schedule:
     - cron: "30 3 * * 1" # toda segunda às 03:30 UTC
 

--- a/backend/src/main/java/br/com/calendar/auth/AuthController.java
+++ b/backend/src/main/java/br/com/calendar/auth/AuthController.java
@@ -4,6 +4,8 @@ import br.com.calendar.auth.dto.AuthResponse;
 import br.com.calendar.auth.dto.ForgotPasswordRequest;
 import br.com.calendar.auth.dto.LoginRequest;
 import br.com.calendar.auth.dto.SignupRequest;
+import br.com.calendar.auth.dto.VerifyOtpRequest;
+import br.com.calendar.auth.dto.VerifyOtpResponse;
 import br.com.calendar.common.dto.MessageResponse;
 import br.com.calendar.user.dto.UserSummaryDTO;
 import io.swagger.v3.oas.annotations.Operation;
@@ -44,6 +46,12 @@ public class AuthController {
     @PostMapping("/auth/forgot-password")
     public ResponseEntity<MessageResponse> requestPasswordReset(@Valid @RequestBody ForgotPasswordRequest request) {
         return ResponseEntity.ok(authService.requestPasswordReset(request));
+    }
+
+    @Operation(summary = "Verify password reset OTP")
+    @PostMapping("/auth/verify-otp")
+    public ResponseEntity<VerifyOtpResponse> verifyOtp(@Valid @RequestBody VerifyOtpRequest request) {
+        return ResponseEntity.ok(authService.verifyOtp(request));
     }
 
     @GetMapping("/me")

--- a/backend/src/main/java/br/com/calendar/auth/AuthService.java
+++ b/backend/src/main/java/br/com/calendar/auth/AuthService.java
@@ -4,6 +4,8 @@ import br.com.calendar.auth.dto.AuthResponse;
 import br.com.calendar.auth.dto.ForgotPasswordRequest;
 import br.com.calendar.auth.dto.LoginRequest;
 import br.com.calendar.auth.dto.SignupRequest;
+import br.com.calendar.auth.dto.VerifyOtpRequest;
+import br.com.calendar.auth.dto.VerifyOtpResponse;
 import br.com.calendar.common.dto.MessageResponse;
 import br.com.calendar.user.User;
 import br.com.calendar.user.UserRepository;
@@ -18,6 +20,9 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.LocalDateTime;
 @Slf4j
 @Service
 public class AuthService {
@@ -68,6 +73,34 @@ public class AuthService {
         );
 
         return new MessageResponse("If the email is registered, password reset instructions will be sent.");
+    }
+
+    public VerifyOtpResponse verifyOtp(VerifyOtpRequest request) {
+        User user = userRepository.findByEmail(request.email())
+                .orElseThrow(AuthService::invalidOtp);
+
+        if (!isOtpValid(user, request.otp())) {
+            throw invalidOtp();
+        }
+        user.setOtp(null);
+        user.setOtpExpiration(null);
+        userRepository.save(user);
+
+        return new VerifyOtpResponse(
+                jwtUtil.generatePasswordResetToken(user.getId()),
+                jwtUtil.getResetExpirationMs() / 1000);
+    }
+
+    private static boolean isOtpValid(User user, String otp) {
+        return user.getOtp() != null
+                && user.getOtpExpiration() != null
+                && user.getOtpExpiration().isAfter(LocalDateTime.now())
+                && MessageDigest.isEqual(user.getOtp().getBytes(StandardCharsets.UTF_8),
+                                         otp.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static ResponseStatusException invalidOtp() {
+        return new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid or expired code");
     }
 
     public UserSummaryDTO me(String userId) {

--- a/backend/src/main/java/br/com/calendar/auth/JwtFilter.java
+++ b/backend/src/main/java/br/com/calendar/auth/JwtFilter.java
@@ -34,7 +34,8 @@ public class JwtFilter extends OncePerRequestFilter {
             String token = header.substring(BEARER_PREFIX.length());
             try {
                 String userId = jwtUtil.extractUserId(token);
-                if (userId != null && !jwtUtil.isExpired(token) && !tokenBlacklist.isRevoked(token)
+                if (userId != null && jwtUtil.getScope(token) == null
+                        && !jwtUtil.isExpired(token) && !tokenBlacklist.isRevoked(token)
                         && SecurityContextHolder.getContext().getAuthentication() == null) {
 
                     var userDetails = org.springframework.security.core.userdetails.User

--- a/backend/src/main/java/br/com/calendar/auth/JwtUtil.java
+++ b/backend/src/main/java/br/com/calendar/auth/JwtUtil.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
+import java.util.UUID;
 
 @Component
 public class JwtUtil {
@@ -26,6 +27,7 @@ public class JwtUtil {
     public String generateToken(String userId) {
         Date now = new Date();
         return Jwts.builder()
+                .id(UUID.randomUUID().toString())
                 .subject(userId)
                 .issuedAt(now)
                 .expiration(new Date(now.getTime() + expirationMs))

--- a/backend/src/main/java/br/com/calendar/auth/JwtUtil.java
+++ b/backend/src/main/java/br/com/calendar/auth/JwtUtil.java
@@ -4,6 +4,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -15,13 +16,22 @@ import java.util.UUID;
 @Component
 public class JwtUtil {
 
+    public static final String SCOPE_PASSWORD_RESET = "password_reset";
+
+    private static final String SCOPE_CLAIM = "scope";
+
     private final SecretKey key;
+    @Getter
     private final long expirationMs;
+    @Getter
+    private final long resetExpirationMs;
 
     public JwtUtil(@Value("${jwt.secret}") String secret,
-                   @Value("${jwt.expiration-ms}") long expirationMs) {
+                   @Value("${jwt.expiration-ms}") long expirationMs,
+                   @Value("${jwt.reset-expiration-ms}") long resetExpirationMs) {
         this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
         this.expirationMs = expirationMs;
+        this.resetExpirationMs = resetExpirationMs;
     }
 
     public String generateToken(String userId) {
@@ -33,6 +43,22 @@ public class JwtUtil {
                 .expiration(new Date(now.getTime() + expirationMs))
                 .signWith(key)
                 .compact();
+    }
+
+    public String generatePasswordResetToken(String userId) {
+        Date now = new Date();
+        return Jwts.builder()
+                .id(UUID.randomUUID().toString())
+                .subject(userId)
+                .claim(SCOPE_CLAIM, SCOPE_PASSWORD_RESET)
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + resetExpirationMs))
+                .signWith(key)
+                .compact();
+    }
+
+    public String getScope(String token) {
+        return parseClaims(token).get(SCOPE_CLAIM, String.class);
     }
 
     public String extractUserId(String token) {
@@ -49,10 +75,6 @@ public class JwtUtil {
         } catch (ExpiredJwtException ex) {
             return true;
         }
-    }
-
-    public long getExpirationMs() {
-        return expirationMs;
     }
 
     private Claims parseClaims(String token) {

--- a/backend/src/main/java/br/com/calendar/auth/dto/VerifyOtpRequest.java
+++ b/backend/src/main/java/br/com/calendar/auth/dto/VerifyOtpRequest.java
@@ -1,0 +1,15 @@
+package br.com.calendar.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record VerifyOtpRequest(
+        @NotBlank(message = "Email is required")
+        @Email(message = "Email must be a valid address")
+        String email,
+
+        @NotBlank(message = "OTP is required")
+        @Pattern(regexp = "\\d{6}", message = "OTP must be 6 digits")
+        String otp) {
+}

--- a/backend/src/main/java/br/com/calendar/auth/dto/VerifyOtpResponse.java
+++ b/backend/src/main/java/br/com/calendar/auth/dto/VerifyOtpResponse.java
@@ -1,0 +1,5 @@
+package br.com.calendar.auth.dto;
+
+
+public record VerifyOtpResponse(String resetToken, long expiresIn) {
+}

--- a/backend/src/main/java/br/com/calendar/category/CategoryRepository.java
+++ b/backend/src/main/java/br/com/calendar/category/CategoryRepository.java
@@ -1,0 +1,6 @@
+package br.com.calendar.category;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, String> {
+}

--- a/backend/src/main/java/br/com/calendar/config/SecurityConfig.java
+++ b/backend/src/main/java/br/com/calendar/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -22,18 +23,19 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http)  {
         String[] swaggerPaths = {"/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui/index.html"};
         http
-                .csrf(csrf -> csrf.disable())
+                .csrf(AbstractHttpConfigurer::disable)
                 .cors(Customizer.withDefaults())
-                .logout(logout -> logout.disable())
+                .logout(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .exceptionHandling(exception -> exception
                         .authenticationEntryPoint((request, response, authException) ->
                                 response.sendError(401, "Unauthorized")))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(HttpMethod.POST, "/auth/login", "/auth/signup", "/auth/forgot-password").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/auth/login", "/auth/signup",
+                                "/auth/forgot-password", "/auth/verify-otp").permitAll()
                         .requestMatchers("/health").permitAll()
                         .requestMatchers(swaggerPaths).permitAll()
                         .anyRequest().authenticated())

--- a/backend/src/main/java/br/com/calendar/domain/LogRepository.java
+++ b/backend/src/main/java/br/com/calendar/domain/LogRepository.java
@@ -1,0 +1,6 @@
+package br.com.calendar.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LogRepository extends JpaRepository<Log, Integer> {
+}

--- a/backend/src/main/java/br/com/calendar/domain/Notification.java
+++ b/backend/src/main/java/br/com/calendar/domain/Notification.java
@@ -1,7 +1,6 @@
 package br.com.calendar.domain;
 
 import br.com.calendar.common.BaseEntity;
-import br.com.calendar.task.Task;
 import br.com.calendar.user.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -12,7 +11,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import org.hibernate.annotations.JdbcType;

--- a/backend/src/main/java/br/com/calendar/domain/NotificationRepository.java
+++ b/backend/src/main/java/br/com/calendar/domain/NotificationRepository.java
@@ -1,0 +1,6 @@
+package br.com.calendar.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, String> {
+}

--- a/backend/src/main/java/br/com/calendar/domain/Task.java
+++ b/backend/src/main/java/br/com/calendar/domain/Task.java
@@ -1,4 +1,4 @@
-package br.com.calendar.task;
+package br.com.calendar.domain;
 
 import br.com.calendar.common.BaseEntity;
 import br.com.calendar.category.Category;

--- a/backend/src/main/java/br/com/calendar/domain/TaskRepository.java
+++ b/backend/src/main/java/br/com/calendar/domain/TaskRepository.java
@@ -1,0 +1,6 @@
+package br.com.calendar.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TaskRepository extends JpaRepository<Task, String> {
+}

--- a/backend/src/main/java/br/com/calendar/user/UserRepository.java
+++ b/backend/src/main/java/br/com/calendar/user/UserRepository.java
@@ -2,7 +2,6 @@ package br.com.calendar.user;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, String> {

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -11,5 +11,6 @@ spring.flyway.locations=classpath:db/migration
 
 jwt.secret=${JWT_SECRET:dev-only-secret-change-in-production-0123456789abcdef}
 jwt.expiration-ms=86400000
+jwt.reset-expiration-ms=300000
 
 cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:${FRONTEND_PORT:4200}}

--- a/backend/src/test/java/br/com/calendar/CalendarApplicationTests.java
+++ b/backend/src/test/java/br/com/calendar/CalendarApplicationTests.java
@@ -2,8 +2,10 @@ package br.com.calendar;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class CalendarApplicationTests {
 
 	@Test

--- a/backend/src/test/java/br/com/calendar/auth/AuthServiceTest.java
+++ b/backend/src/test/java/br/com/calendar/auth/AuthServiceTest.java
@@ -4,6 +4,8 @@ import br.com.calendar.auth.dto.AuthResponse;
 import br.com.calendar.auth.dto.ForgotPasswordRequest;
 import br.com.calendar.auth.dto.LoginRequest;
 import br.com.calendar.auth.dto.SignupRequest;
+import br.com.calendar.auth.dto.VerifyOtpRequest;
+import br.com.calendar.auth.dto.VerifyOtpResponse;
 import br.com.calendar.common.dto.MessageResponse;
 import br.com.calendar.user.User;
 import br.com.calendar.user.UserRepository;
@@ -22,10 +24,12 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.security.SecureRandom;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -140,6 +144,81 @@ class AuthServiceTest {
 
         assertThrows(ResponseStatusException.class,
                 () -> authService.login(new LoginRequest("unknown@example.com", "any-password")));
+    }
+
+    @Test
+    void verifyOtpWithValidCodeReturnsResetTokenAndBurnsTheOtp() {
+        User user = userWithOtp("123456", LocalDateTime.now().plusMinutes(5));
+
+        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+        when(jwtUtil.generatePasswordResetToken(USER_ID)).thenReturn("reset-token");
+        when(jwtUtil.getResetExpirationMs()).thenReturn(300000L);
+
+        VerifyOtpResponse response = authService.verifyOtp(
+                new VerifyOtpRequest("test@example.com", "123456"));
+
+        assertEquals("reset-token", response.resetToken());
+        assertEquals(300, response.expiresIn());
+        assertNull(user.getOtp());
+        assertNull(user.getOtpExpiration());
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    void verifyOtpWithWrongCodeThrows() {
+        User user = userWithOtp("123456", LocalDateTime.now().plusMinutes(5));
+
+        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+
+        assertThrows(ResponseStatusException.class, () -> authService.verifyOtp(
+                new VerifyOtpRequest("test@example.com", "999999")));
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    void verifyOtpWithExpiredCodeThrows() {
+        User user = userWithOtp("123456", LocalDateTime.now().minusMinutes(1));
+
+        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+
+        assertThrows(ResponseStatusException.class, () -> authService.verifyOtp(
+                new VerifyOtpRequest("test@example.com", "123456")));
+    }
+
+    @Test
+    void verifyOtpWithAlreadyUsedCodeThrows() {
+        User user = userWithOtp(null, null);
+
+        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+
+        assertThrows(ResponseStatusException.class, () -> authService.verifyOtp(
+                new VerifyOtpRequest("test@example.com", "123456")));
+    }
+
+    @Test
+    void verifyOtpWithUnknownEmailThrowsTheSameErrorAsAWrongCode() {
+        User user = userWithOtp("123456", LocalDateTime.now().plusMinutes(5));
+
+        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+        when(userRepository.findByEmail("unknown@example.com")).thenReturn(Optional.empty());
+
+        ResponseStatusException unknownEmail = assertThrows(ResponseStatusException.class,
+                () -> authService.verifyOtp(new VerifyOtpRequest("unknown@example.com", "123456")));
+        ResponseStatusException wrongCode = assertThrows(ResponseStatusException.class,
+                () -> authService.verifyOtp(new VerifyOtpRequest("test@example.com", "999999")));
+
+        // identical status and message, otherwise the route leaks which emails are registered
+        assertEquals(wrongCode.getStatusCode(), unknownEmail.getStatusCode());
+        assertEquals(wrongCode.getReason(), unknownEmail.getReason());
+    }
+
+    private static User userWithOtp(String otp, LocalDateTime expiration) {
+        User user = new User();
+        user.setId(USER_ID);
+        user.setEmail("test@example.com");
+        user.setOtp(otp);
+        user.setOtpExpiration(expiration);
+        return user;
     }
 
     @Test

--- a/backend/src/test/java/br/com/calendar/auth/JwtUtilTest.java
+++ b/backend/src/test/java/br/com/calendar/auth/JwtUtilTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -17,7 +18,7 @@ class JwtUtilTest {
 
     @BeforeEach
     void setUp() {
-        jwtUtil = new JwtUtil(SECRET, 86400000L);
+        jwtUtil = new JwtUtil(SECRET, 86400000L, 300000L);
     }
 
     @Test
@@ -36,10 +37,25 @@ class JwtUtilTest {
 
     @Test
     void expiredTokenIsDetected() {
-        JwtUtil shortLivedJwt = new JwtUtil(SECRET, -1000L);
+        JwtUtil shortLivedJwt = new JwtUtil(SECRET, -1000L, -1000L);
         String token = shortLivedJwt.generateToken(USER_ID);
 
         assertTrue(shortLivedJwt.isExpired(token));
+    }
+
+    @Test
+    void accessTokenHasNoScope() {
+        String token = jwtUtil.generateToken(USER_ID);
+
+        assertNull(jwtUtil.getScope(token));
+    }
+
+    @Test
+    void passwordResetTokenIsScoped() {
+        String token = jwtUtil.generatePasswordResetToken(USER_ID);
+
+        assertEquals(USER_ID, jwtUtil.extractUserId(token));
+        assertEquals(JwtUtil.SCOPE_PASSWORD_RESET, jwtUtil.getScope(token));
     }
 
     @Test


### PR DESCRIPTION
## Description

Implements `POST /auth/verify-otp`, the second step of the password recovery
flow, and fixes three problems found while getting the branch green.

**The endpoint.** It validates the code sent by `/auth/forgot-password` and
returns a short lived token that authorizes the password change. Three
decisions worth reviewing:

- The OTP is single use. It is cleared on a successful verification, so the
  authorization travels in the token from then on and a replayed code is
  rejected.
- The token carries a `scope` claim, and `JwtFilter` now refuses to
  authenticate any scoped token. Without that a reset token would work as a
  full access bearer, since both are signed with the same key.
- Unknown email, wrong code, expired code and already used code all return the
  same `400`, so the route does not become an account enumeration oracle.

The request takes `email` and `otp`. Issue #39 lists only `otp`, but looking a
user up by a six digit code is not safe when two of them can hold the same one
at the same time.

**The CI was never running.** All five workflows watched a `develop` branch
that does not exist in this repository. The integration branch is
`development`, so no backend, frontend, desktop, mobile or CodeQL run was
triggered by the pull requests targeting it. `docker-build-push.yml` only
watches `main` and was left untouched.

**Two tests were broken underneath that.** `contextLoads` could not start the
context because `PasswordConfig` requires `secret.password.pepper`, which is
only defined in `application-test.properties`. And `logoutReturns204` failed
depending on test order: two logins by the same user inside the same second
produced a byte identical token, so revoking one session revoked the other.
That second one is a production bug, not just a flaky test.

The remaining commit adds the JPA repositories for `Category`, `Task`,
`Notification` and `Log`, which had none.

### Known gap

There is no attempt counter on the OTP, so a six digit code is brute forceable
inside its fifteen minute window. This route needs rate limiting before
production. It is marked in the code and left out of this PR deliberately.

## Type of change

- [x] New feature
- [x] Bug fix
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [x] Infrastructure / CI / CD / Docker
- [ ] Other:

## Affected module(s)

- [x] backend
- [ ] frontend
- [ ] desktop
- [ ] mobile
- [x] infra (docker / CI / CD)

## How to test

1. Start the database and the application:
   `docker compose -f docker-compose.dev.yml up --build`
2. Create a user and request a code:
   ```
   curl -X POST localhost:8080/auth/signup -H 'Content-Type: application/json' \
     -d '{"name":"Test","email":"test@example.com","password":"secret123"}'
   curl -X POST localhost:8080/auth/forgot-password -H 'Content-Type: application/json' \
     -d '{"email":"test@example.com"}'
   ```
3. Read the generated code from the application log (SMTP is not configured
   yet), then verify it:
   ```
   curl -X POST localhost:8080/auth/verify-otp -H 'Content-Type: application/json' \
     -d '{"email":"test@example.com","otp":"<code>"}'
   ```
   Expect `200` with `resetToken` and `expiresIn`.
4. Check the guarantees: replaying the same code returns `400`, an unknown
   email returns the same `400`, and the returned token used as
   `Authorization: Bearer` on `/me` returns `401`.

## Checklist

- [x] I ran the tests locally and they passed
- [ ] I updated the documentation (README/CONTRIBUTING), if necessary
- [x] I did not leave any `console.log` / `System.out.println` / `print` debug statements
- [x] I followed the project's commit convention (Conventional Commits)
- [x] I reviewed my own diff before opening the PR

## Related issue

Closes #39
