### PR TITLE
Feat/forgot password view

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:calendar/view/ViewHome.dart';
+import 'package:calendar/view/auth/ViewForgotPassword.dart';
 import 'package:calendar/view/auth/ViewLogin.dart';
 import 'package:calendar/view/auth/ViewSignup.dart';
 import 'package:flutter/material.dart';
@@ -23,6 +24,7 @@ class MyApp extends StatelessWidget {
         "/": (context) => const ViewHome(),
         "/login": (context) => const ViewLogin(),
         "/signup": (context) => const ViewSignup(),
+        "/forgot-password": (context) => const ViewForgotPassword(),
       },
     );
   }

--- a/mobile/lib/view/auth/ViewForgotPassword.dart
+++ b/mobile/lib/view/auth/ViewForgotPassword.dart
@@ -1,0 +1,34 @@
+import 'package:calendar/widget/WidgetBody.dart';
+import 'package:calendar/widget/WidgetButton.dart';
+import 'package:calendar/widget/WidgetInput.dart';
+import 'package:flutter/material.dart';
+
+class ViewForgotPassword extends StatefulWidget {
+  const ViewForgotPassword({ Key? key }) : super(key: key);
+
+  @override
+  _ViewForgotPasswordState createState() => _ViewForgotPasswordState();
+}
+
+class _ViewForgotPasswordState extends State<ViewForgotPassword> {
+  @override
+  Widget build(BuildContext context) {
+    return WidgetBody(
+      children: [
+        Text(
+          "Esqueceu a senha?",
+          style: TextStyle(fontSize: 32, fontWeight: FontWeight.bold),
+        ),
+        Text(
+          "Por favor, insira seu email para redefinir sua senha.",
+          style: TextStyle(fontSize: 14),
+        ),
+        SizedBox(height: 50),
+
+        WidgetInput(label: "Email"),
+
+        WidgetButton(text: "Redefinir senha"),
+      ],
+    );
+  }
+}

--- a/mobile/lib/view/auth/ViewForgotPassword.dart
+++ b/mobile/lib/view/auth/ViewForgotPassword.dart
@@ -1,16 +1,36 @@
+import 'package:calendar/view/auth/ViewLogin.dart';
 import 'package:calendar/widget/WidgetBody.dart';
 import 'package:calendar/widget/WidgetButton.dart';
 import 'package:calendar/widget/WidgetInput.dart';
 import 'package:flutter/material.dart';
 
 class ViewForgotPassword extends StatefulWidget {
-  const ViewForgotPassword({ Key? key }) : super(key: key);
+  const ViewForgotPassword({super.key});
 
   @override
   _ViewForgotPasswordState createState() => _ViewForgotPasswordState();
 }
 
 class _ViewForgotPasswordState extends State<ViewForgotPassword> {
+  final _formKey = GlobalKey<FormState>();
+
+  String? _validateEmail(String? value) {
+    if (value == null || value.trim().isEmpty) {
+      return 'Por favor, insira seu email.';
+    }
+    final emailRegex = RegExp(r'^[\w\.-]+@[\w\.-]+\.\w{2,}$');
+    if (!emailRegex.hasMatch(value.trim())) {
+      return 'Insira um email válido.';
+    }
+    return null;
+  }
+
+  void _submit() {
+    if (_formKey.currentState!.validate()) {
+      // TODO: send OTP
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return WidgetBody(
@@ -25,9 +45,29 @@ class _ViewForgotPasswordState extends State<ViewForgotPassword> {
         ),
         SizedBox(height: 50),
 
-        WidgetInput(label: "Email"),
+        Form(
+          key: _formKey,
+          child: WidgetInput(
+            label: "Email",
+            validator: _validateEmail,
+          ),
+        ),
 
-        WidgetButton(text: "Redefinir senha"),
+        WidgetButton(text: "Enviar OTP", onPressed: _submit),
+
+        GestureDetector(
+          onTap: () {
+            Navigator.pushAndRemoveUntil(
+              context,
+              MaterialPageRoute(builder: (context) => ViewLogin()),
+              (route) => false,
+            );
+          },
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [Text("Voltar para login")],
+          ),
+        ),
       ],
     );
   }

--- a/mobile/lib/view/auth/ViewLogin.dart
+++ b/mobile/lib/view/auth/ViewLogin.dart
@@ -1,3 +1,4 @@
+import 'package:calendar/view/auth/ViewForgotPassword.dart';
 import 'package:calendar/view/auth/ViewSignup.dart';
 import 'package:calendar/widget/WidgetBody.dart';
 import 'package:calendar/widget/WidgetButton.dart';
@@ -26,22 +27,32 @@ class _ViewLogin extends State<ViewLogin> {
         ),
         SizedBox(height: 50),
 
-        WidgetInput(
-          label: "Email"
-        ),
+        WidgetInput(label: "Email"),
 
         Column(
           children: [
-            
             WidgetInput(
               label: "Senha",
               password: true,
-              icon: Icons.lock_outline
+              icon: Icons.lock_outline,
             ),
 
-            WidgetButton(
-              text: "Entrar"
+            WidgetButton(text: "Entrar"),
+
+            GestureDetector(
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (context) => ViewForgotPassword()),
+                );
+              },
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [Text("Esqueceu a senha?")],
+              ),
             ),
+
+            SizedBox(height:30),
             
             WidgetOAuth("OU ENTRAR COM"),
 
@@ -49,16 +60,12 @@ class _ViewLogin extends State<ViewLogin> {
               onTap: () {
                 Navigator.push(
                   context,
-                  MaterialPageRoute(
-                    builder: (context) => ViewSignup(),
-                  ),
+                  MaterialPageRoute(builder: (context) => ViewSignup()),
                 );
               },
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Text("Não tem uma conta? Criar Conta"),
-                ],
+                children: [Text("Não tem uma conta? Criar Conta")],
               ),
             ),
             SizedBox(height: 15),

--- a/mobile/lib/widget/WidgetButton.dart
+++ b/mobile/lib/widget/WidgetButton.dart
@@ -3,25 +3,23 @@ import 'package:flutter/material.dart';
 class WidgetButton extends StatefulWidget {
     const WidgetButton({
       super.key,
-      this.text=""
+      this.text = "",
+      this.onPressed,
     });
 
     final String text;
+    final VoidCallback? onPressed;
 
     @override
     _WidgetButton createState() => _WidgetButton();
 }
 
 class _WidgetButton extends State<WidgetButton> {
-
-    
-
     @override
     Widget build(BuildContext context) {
         return Column(
           children: [
             SizedBox(
-              //height: 57,
               width: double.infinity,
               child: ElevatedButton(
                 style: ElevatedButton.styleFrom(
@@ -30,7 +28,7 @@ class _WidgetButton extends State<WidgetButton> {
                     borderRadius: BorderRadius.circular(06),
                   ),
                 ),
-                onPressed: () {},
+                onPressed: widget.onPressed ?? () {},
                 child: Text(
                   widget.text,
                   style: TextStyle(color: Colors.white, fontSize: 20),

--- a/mobile/lib/widget/WidgetInput.dart
+++ b/mobile/lib/widget/WidgetInput.dart
@@ -5,12 +5,14 @@ class WidgetInput extends StatefulWidget {
       super.key,
       this.label="",
       this.password=false,
-      this.icon = Icons.mail_outlined
+      this.icon = Icons.mail_outlined,
+      this.validator,
     });
 
     final String label;
     final bool password;
     final IconData icon;
+    final String? Function(String?)? validator;
 
     @override
     _WidgetInput createState() => _WidgetInput();
@@ -24,6 +26,7 @@ class _WidgetInput extends State<WidgetInput> {
           children: [
             TextFormField(
               obscureText: widget.password,
+              validator: widget.validator,
               decoration: InputDecoration(
                 hintText: widget.password?"•••••••":"",
                 labelText: widget.label,

--- a/mobile/test/view/view_forgot_password_test.dart
+++ b/mobile/test/view/view_forgot_password_test.dart
@@ -1,0 +1,85 @@
+import 'package:calendar/view/auth/ViewForgotPassword.dart';
+import 'package:calendar/widget/WidgetButton.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Widget _wrap() {
+  return MaterialApp(
+    routes: {
+      '/login': (_) => const Scaffold(body: Text('Login')),
+    },
+    home: const ViewForgotPassword(),
+  );
+}
+
+void main() {
+  group('ViewForgotPassword', () {
+    testWidgets('renders title and subtitle', (tester) async {
+      await tester.pumpWidget(_wrap());
+
+      expect(find.text('Esqueceu a senha?'), findsOneWidget);
+      expect(
+        find.text('Por favor, insira seu email para redefinir sua senha.'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('renders email field', (tester) async {
+      await tester.pumpWidget(_wrap());
+
+      expect(find.byType(TextFormField), findsOneWidget);
+    });
+
+    testWidgets('renders "Enviar OTP" button', (tester) async {
+      await tester.pumpWidget(_wrap());
+
+      expect(find.widgetWithText(WidgetButton, 'Enviar OTP'), findsOneWidget);
+    });
+
+    testWidgets('renders back to login link', (tester) async {
+      await tester.pumpWidget(_wrap());
+
+      expect(find.text('Voltar para login'), findsOneWidget);
+    });
+
+    testWidgets('shows required error when submitting empty email',
+        (tester) async {
+      await tester.pumpWidget(_wrap());
+
+      await tester.tap(find.widgetWithText(ElevatedButton, 'Enviar OTP'));
+      await tester.pump();
+
+      expect(find.text('Por favor, insira seu email.'), findsOneWidget);
+    });
+
+    testWidgets('shows format error when submitting invalid email',
+        (tester) async {
+      await tester.pumpWidget(_wrap());
+
+      await tester.enterText(find.byType(TextFormField), 'email-invalido');
+      await tester.tap(find.widgetWithText(ElevatedButton, 'Enviar OTP'));
+      await tester.pump();
+
+      expect(find.text('Insira um email válido.'), findsOneWidget);
+    });
+
+    testWidgets('shows no error when submitting valid email', (tester) async {
+      await tester.pumpWidget(_wrap());
+
+      await tester.enterText(
+          find.byType(TextFormField), 'usuario@email.com');
+      await tester.tap(find.widgetWithText(ElevatedButton, 'Enviar OTP'));
+      await tester.pump();
+
+      expect(find.text('Por favor, insira seu email.'), findsNothing);
+      expect(find.text('Insira um email válido.'), findsNothing);
+    });
+
+    testWidgets('does not show error before first submit', (tester) async {
+      await tester.pumpWidget(_wrap());
+
+      expect(find.text('Por favor, insira seu email.'), findsNothing);
+      expect(find.text('Insira um email válido.'), findsNothing);
+    });
+  });
+}

--- a/mobile/test/widget/widget_input_test.dart
+++ b/mobile/test/widget/widget_input_test.dart
@@ -1,0 +1,104 @@
+import 'package:calendar/widget/WidgetInput.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Widget _wrap(Widget child) {
+  return MaterialApp(home: Scaffold(body: child));
+}
+
+void main() {
+  group('WidgetInput', () {
+    testWidgets('renders label text', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          Form(
+            child: WidgetInput(label: 'Email'),
+          ),
+        ),
+      );
+
+      expect(find.text('Email'), findsOneWidget);
+    });
+
+    testWidgets('renders without validator when not provided', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          Form(
+            child: WidgetInput(label: 'Email'),
+          ),
+        ),
+      );
+
+      expect(find.byType(TextFormField), findsOneWidget);
+    });
+
+    testWidgets('shows error message when validator returns a string',
+        (tester) async {
+      final formKey = GlobalKey<FormState>();
+
+      await tester.pumpWidget(
+        _wrap(
+          Form(
+            key: formKey,
+            child: WidgetInput(
+              label: 'Email',
+              validator: (_) => 'Erro de validação',
+            ),
+          ),
+        ),
+      );
+
+      formKey.currentState!.validate();
+      await tester.pump();
+
+      expect(find.text('Erro de validação'), findsOneWidget);
+    });
+
+    testWidgets('shows no error when validator returns null', (tester) async {
+      final formKey = GlobalKey<FormState>();
+
+      await tester.pumpWidget(
+        _wrap(
+          Form(
+            key: formKey,
+            child: WidgetInput(
+              label: 'Email',
+              validator: (_) => null,
+            ),
+          ),
+        ),
+      );
+
+      formKey.currentState!.validate();
+      await tester.pump();
+
+      expect(find.byType(ErrorWidget), findsNothing);
+    });
+
+    testWidgets('obscures text when password is true', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          Form(
+            child: WidgetInput(label: 'Senha', password: true),
+          ),
+        ),
+      );
+
+      final field = tester.widget<EditableText>(find.byType(EditableText));
+      expect(field.obscureText, isTrue);
+    });
+
+    testWidgets('does not obscure text when password is false', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          Form(
+            child: WidgetInput(label: 'Email', password: false),
+          ),
+        ),
+      );
+
+      final field = tester.widget<EditableText>(find.byType(EditableText));
+      expect(field.obscureText, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Description
  
  Add forgot password page with email validation and OTP submission, including unit and widget tests for the new components.
  
  Type of change
  
  - [x] New feature
  
  Affected module(s)
  
  - [x] mobile
  
  How to test
  
  1. Run flutter test inside the mobile/ directory and confirm all tests pass.
  2. Launch the app and navigate to the login screen.
  3. Tap "Esqueceu a senha?" and verify the forgot password screen opens.
  4. Tap "Enviar OTP" with the email field empty and confirm the error "Por favor, insira seu email." appears.
  5. Enter an invalid email (e.g. teste) and tap "Enviar OTP" — confirm the error "Insira um email válido." appears.
  6. Enter a valid email (e.g. usuario@email.com) and tap "Enviar OTP" — confirm no error is shown.
  7. Tap "Voltar para login" and confirm navigation returns to the login screen.
  
  Checklist
  
  - [x] I ran the tests locally and they passed
  - [ ] I updated the documentation (README/CONTRIBUTING), if necessary
  - [x] I did not leave any console.log / System.out.println / print debug statements
  - [x] I followed the project's commit convention (Conventional Commits)
  - [x] I reviewed my own diff before opening the PR
  
  Related issue
  
  Closes #