### PR TITLE
feat: add audit tables and triggers

### DIFF
--- a/backend/src/main/resources/db/migration/V4__Create_audit_tables.sql
+++ b/backend/src/main/resources/db/migration/V4__Create_audit_tables.sql
@@ -1,0 +1,20 @@
+--Tabela auditoria para usuarios
+-- data se refere ao dado armazenado, old_data e new_data armazenam essa alteracao de dados
+CREATE TABLE audit_users(
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY ,
+    users_id BIGINT NOT NULL ,
+    action VARCHAR(10) NOT NULL ,
+    old_data JSONB,
+    new_data JSONB,
+    created_at TIMESTAMPZ DEFAULT CURRENT_TIMESTAMP
+);
+
+--Tabela auditoria para tasks
+CREATE TABLE audit_tasks(
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY ,
+    task_id BIGINT NOT NULL,
+    action VARCHAR(10) NOT NULL ,
+    old_data JSONB,
+    new_data JSONB,
+    created_at TIMESTAMPZ DEFAULT CURRENT_TIMESTAMP
+);

--- a/backend/src/main/resources/db/migration/V5__Create_audit_functions.sql
+++ b/backend/src/main/resources/db/migration/V5__Create_audit_functions.sql
@@ -1,0 +1,53 @@
+--function TRIGGER for audit users
+CREATE OR REPLACE FUNCTION log_users_audit()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF (TG_OP = 'INSERT') THEN
+        INSERT INTO audit_users (user_id, action, old_data, new_data)
+        VALUES (NEW.id, 'INSERT', NULL, row_to_json(NEW)::jsonb);
+RETURN NEW;
+
+ELSIF (TG_OP = 'UPDATE') THEN
+        -- Registra o log APENAS se algum valor realmente mudou
+        IF (NEW IS DISTINCT FROM OLD) THEN
+            INSERT INTO audit_users (user_id, action, old_data, new_data)
+            VALUES (NEW.id, 'UPDATE', row_to_json(OLD)::jsonb, row_to_json(NEW)::jsonb);
+END IF;
+RETURN NEW;
+
+ELSIF (TG_OP = 'DELETE') THEN
+        INSERT INTO audit_users (user_id, action, old_data, new_data)
+        VALUES (OLD.id, 'DELETE', row_to_json(OLD)::jsonb, NULL);
+RETURN OLD;
+END IF;
+
+RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+--function TRIGGER for audit tasks
+   CREATE OR REPLACE FUNCTION log_tasks_audit()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF (TG_OP = 'INSERT') THEN
+        INSERT INTO audit_tasks (task_id, action, old_data, new_data)
+        VALUES (NEW.id, 'INSERT', NULL, row_to_json(NEW)::jsonb);
+RETURN NEW;
+
+ELSIF (TG_OP = 'UPDATE') THEN
+        -- Registra o log APENAS se algum valor da task realmente mudou
+        IF (NEW IS DISTINCT FROM OLD) THEN
+            INSERT INTO audit_tasks (task_id, action, old_data, new_data)
+            VALUES (NEW.id, 'UPDATE', row_to_json(OLD)::jsonb, row_to_json(NEW)::jsonb);
+END IF;
+RETURN NEW;
+
+ELSIF (TG_OP = 'DELETE') THEN
+        INSERT INTO audit_tasks (task_id, action, old_data, new_data)
+        VALUES (OLD.id, 'DELETE', row_to_json(OLD)::jsonb, NULL);
+RETURN OLD;
+END IF;
+
+RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;

--- a/backend/src/main/resources/db/migration/V6__Create_audit_triggers.sql
+++ b/backend/src/main/resources/db/migration/V6__Create_audit_triggers.sql
@@ -1,0 +1,9 @@
+--TRIGGER table users
+CREATE TRIGGER users_audit_trigger
+    AFTER INSERT OR UPDATE OR DELETE ON users
+    FOR EACH ROW EXECUTE FUNCTION log_users_audit();
+
+--TRIGGER table tasks
+CREATE TRIGGER tasks_audit_trigger
+    AFTER INSERT OR UPDATE OR DELETE ON tasks
+    FOR EACH ROW EXECUTE FUNCTION log_tasks_audit();


### PR DESCRIPTION
## Description

Added audit tables and database triggers. 
These structures were created to automatically track and log the history of data changes, ensuring greater security and data traceability for the application.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Infrastructure / CI / CD / Docker
- [ ] Other:

## Affected module(s)

- [x] backend
- [ ] frontend
- [ ] desktop
- [ ] mobile
- [ ] infra (docker / CI / CD)

## How to test

1. Run the SQL migration script (`V6_Create_audit_triggers.sql`) in your local database to create the audit tables and triggers.
2. Start the backend application.
3. Perform operations (`INSERT`, `UPDATE`, or `DELETE`) on the main tables using an API client (like Postman/Swagger) or the frontend.
4. Access your database and verify if the audit tables correctly logged these operations.

## Checklist

- [x] I ran the tests locally and they passed
- [ ] I updated the documentation (README/CONTRIBUTING), if necessary
- [x] I did not leave any `console.log` / `System.out.println` / `print` debug statements
- [x] I followed the project's commit convention (Conventional Commits)
- [x] I reviewed my own diff before opening the PR

## Related issue

Closes # 