### PR TITLE
feat: add get categories endpoint

### DIFF
--- a/backend/src/main/java/br/com/calendar/category/Category.java
+++ b/backend/src/main/java/br/com/calendar/category/Category.java
@@ -29,4 +29,7 @@ public class Category extends BaseEntity {
 
     @Column(length = 6)
     private String color;
+
+    @Column(length = 255)
+    private String icon;
 }

--- a/backend/src/main/java/br/com/calendar/category/CategoryController.java
+++ b/backend/src/main/java/br/com/calendar/category/CategoryController.java
@@ -1,0 +1,34 @@
+package br.com.calendar.category;
+
+import br.com.calendar.category.dto.CategoryResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/categories")
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    public CategoryController(CategoryService categoryService) {
+        this.categoryService = categoryService;
+    }
+
+    @Operation(summary = "Get the authenticated user's categories")
+    @GetMapping
+    public ResponseEntity<List<CategoryResponseDTO>> getCategories(Authentication authentication) {
+        if (authentication == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Not authenticated");
+        }
+
+        return ResponseEntity.ok(categoryService.getCategories(authentication.getName()));
+    }
+}

--- a/backend/src/main/java/br/com/calendar/category/CategoryMapper.java
+++ b/backend/src/main/java/br/com/calendar/category/CategoryMapper.java
@@ -1,0 +1,16 @@
+package br.com.calendar.category;
+
+import br.com.calendar.category.dto.CategoryResponseDTO;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CategoryMapper {
+
+    public CategoryResponseDTO toResponse(Category category) {
+        return new CategoryResponseDTO(
+                category.getId(),
+                category.getTitle(),
+                category.getColor(),
+                category.getIcon());
+    }
+}

--- a/backend/src/main/java/br/com/calendar/category/CategoryRepository.java
+++ b/backend/src/main/java/br/com/calendar/category/CategoryRepository.java
@@ -2,5 +2,9 @@ package br.com.calendar.category;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CategoryRepository extends JpaRepository<Category, String> {
+
+    List<Category> findAllByUser_Id(String userId);
 }

--- a/backend/src/main/java/br/com/calendar/category/CategoryService.java
+++ b/backend/src/main/java/br/com/calendar/category/CategoryService.java
@@ -1,0 +1,26 @@
+package br.com.calendar.category;
+
+import br.com.calendar.category.dto.CategoryResponseDTO;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+    private final CategoryMapper categoryMapper;
+
+    public CategoryService(CategoryRepository categoryRepository, CategoryMapper categoryMapper) {
+        this.categoryRepository = categoryRepository;
+        this.categoryMapper = categoryMapper;
+    }
+
+    @Transactional(readOnly = true)
+    public List<CategoryResponseDTO> getCategories(String userId) {
+        return categoryRepository.findAllByUser_Id(userId).stream()
+                .map(categoryMapper::toResponse)
+                .toList();
+    }
+}

--- a/backend/src/main/java/br/com/calendar/category/dto/CategoryResponseDTO.java
+++ b/backend/src/main/java/br/com/calendar/category/dto/CategoryResponseDTO.java
@@ -1,0 +1,8 @@
+package br.com.calendar.category.dto;
+
+public record CategoryResponseDTO(
+        String id,
+        String title,
+        String color,
+        String icon) {
+}

--- a/backend/src/main/resources/db/migration/V7__add_icon_to_category.sql
+++ b/backend/src/main/resources/db/migration/V7__add_icon_to_category.sql
@@ -1,0 +1,4 @@
+-- V7 - add the icon returned by the categories API
+
+ALTER TABLE category
+    ADD COLUMN icon varchar(255);

--- a/backend/src/test/java/br/com/calendar/category/CategoryControllerTest.java
+++ b/backend/src/test/java/br/com/calendar/category/CategoryControllerTest.java
@@ -1,0 +1,64 @@
+package br.com.calendar.category;
+
+import br.com.calendar.category.dto.CategoryResponseDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class CategoryControllerTest {
+
+    private static final String USER_ID = "usr_abc123";
+
+    @Mock
+    private CategoryService categoryService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new CategoryController(categoryService))
+                .build();
+    }
+
+    @Test
+    void returnsTheAuthenticatedUsersCategories() throws Exception {
+        when(categoryService.getCategories(USER_ID)).thenReturn(List.of(
+                new CategoryResponseDTO("cat_123", "Work", "3366FF", "briefcase")));
+
+        mockMvc.perform(get("/categories")
+                        .principal(new UsernamePasswordAuthenticationToken(USER_ID, null)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value("cat_123"))
+                .andExpect(jsonPath("$[0].title").value("Work"))
+                .andExpect(jsonPath("$[0].color").value("3366FF"))
+                .andExpect(jsonPath("$[0].icon").value("briefcase"));
+
+        verify(categoryService).getCategories(USER_ID);
+    }
+
+    @Test
+    void returnsAnEmptyArrayWhenTheUserHasNoCategories() throws Exception {
+        when(categoryService.getCategories(USER_ID)).thenReturn(List.of());
+
+        mockMvc.perform(get("/categories")
+                        .principal(new UsernamePasswordAuthenticationToken(USER_ID, null)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$").isEmpty());
+    }
+}

--- a/backend/src/test/java/br/com/calendar/category/CategoryServiceTest.java
+++ b/backend/src/test/java/br/com/calendar/category/CategoryServiceTest.java
@@ -1,0 +1,67 @@
+package br.com.calendar.category;
+
+import br.com.calendar.category.dto.CategoryResponseDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CategoryServiceTest {
+
+    private static final String USER_ID = "usr_abc123";
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @Mock
+    private CategoryMapper categoryMapper;
+
+    private CategoryService categoryService;
+
+    @BeforeEach
+    void setUp() {
+        categoryService = new CategoryService(categoryRepository, categoryMapper);
+    }
+
+    @Test
+    void returnsCategoriesForTheAuthenticatedUser() {
+        Category category = new Category();
+        category.setId("cat_123");
+        category.setTitle("Work");
+        category.setColor("3366FF");
+        category.setIcon("briefcase");
+
+        CategoryResponseDTO expected = new CategoryResponseDTO(
+                "cat_123", "Work", "3366FF", "briefcase");
+
+        when(categoryRepository.findAllByUser_Id(USER_ID)).thenReturn(List.of(category));
+        when(categoryMapper.toResponse(category)).thenReturn(expected);
+
+        List<CategoryResponseDTO> response = categoryService.getCategories(USER_ID);
+
+        assertEquals(List.of(expected), response);
+        verify(categoryRepository).findAllByUser_Id(USER_ID);
+        verify(categoryMapper).toResponse(category);
+    }
+
+    @Test
+    void returnsAnEmptyListWhenTheUserHasNoCategories() {
+        when(categoryRepository.findAllByUser_Id(USER_ID)).thenReturn(List.of());
+
+        List<CategoryResponseDTO> response = categoryService.getCategories(USER_ID);
+
+        assertTrue(response.isEmpty());
+        verify(categoryRepository).findAllByUser_Id(USER_ID);
+        verifyNoInteractions(categoryMapper);
+    }
+}


### PR DESCRIPTION
## Description

Adds the authenticated `GET /categories` endpoint to list categories owned by the current user.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Infrastructure / CI / CD / Docker
- [ ] Other:

## Affected module(s)

- [x] backend
- [ ] frontend
- [ ] desktop
- [ ] mobile
- [ ] infra (docker / CI / CD)

## How to test

1. Authenticate with a valid user.
2. Send a `GET /categories` request.
3. Verify that only the authenticated user's categories are returned.
4. Verify that each category contains `id`, `title`, `color`, and `icon`.
5. Verify that a user with no categories receives an empty array.

## Checklist

- [x] I ran the tests locally and they passed
- [ ] I updated the documentation (README/CONTRIBUTING), if necessary
- [x] I did not leave any `console.log` / `System.out.println` / `print` debug statements
- [x] I followed the project's commit convention (Conventional Commits)
- [x] I reviewed my own diff before opening the PR

## Related issue

Closes #114