### PR TITLE
Feat/update task endpoint

### DIFF
--- a/backend/src/main/java/br/com/calendar/category/CategoryRepository.java
+++ b/backend/src/main/java/br/com/calendar/category/CategoryRepository.java
@@ -1,10 +1,14 @@
 package br.com.calendar.category;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CategoryRepository extends JpaRepository<Category, String> {
 
     List<Category> findAllByUser_Id(String userId);
+
+    Optional<Category> findByIdAndUser_Id(String categoryId, String userId);
+
 }

--- a/backend/src/main/java/br/com/calendar/category/CategoryService.java
+++ b/backend/src/main/java/br/com/calendar/category/CategoryService.java
@@ -1,10 +1,12 @@
 package br.com.calendar.category;
 
-import br.com.calendar.category.dto.CategoryResponseDTO;
+import java.util.List;
+
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import br.com.calendar.category.dto.CategoryResponseDTO;
 
 @Service
 public class CategoryService {
@@ -22,5 +24,11 @@ public class CategoryService {
         return categoryRepository.findAllByUser_Id(userId).stream()
                 .map(categoryMapper::toResponse)
                 .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public Category getCategoryOwnedByUser(String categoryId, String userId) {
+        return categoryRepository.findByIdAndUser_Id(categoryId, userId)
+                .orElseThrow(() -> new AccessDeniedException("Category does not belong to the current user"));
     }
 }

--- a/backend/src/main/java/br/com/calendar/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/br/com/calendar/common/exception/GlobalExceptionHandler.java
@@ -41,4 +41,12 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.INTERNAL_SERVER_ERROR, "Unexpected error");
         return handleExceptionInternal(e, problem, new HttpHeaders(), HttpStatus.INTERNAL_SERVER_ERROR, request);
     }
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<Object> handleResourceNotFoundException(ResourceNotFoundException e, WebRequest request) {
+        log.error("Resource not found", e);
+
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, e.getMessage());
+        return handleExceptionInternal(e, problem, new HttpHeaders(), HttpStatus.NOT_FOUND, request);
+    }
 }

--- a/backend/src/main/java/br/com/calendar/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/br/com/calendar/common/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package br.com.calendar.common.exception;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
 import org.springframework.http.*;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -48,5 +49,13 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
         ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, e.getMessage());
         return handleExceptionInternal(e, problem, new HttpHeaders(), HttpStatus.NOT_FOUND, request);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<Object> handleAccessDeniedException(AccessDeniedException e, WebRequest request) {
+        log.error("Access denied", e);
+
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.FORBIDDEN, e.getMessage());
+        return handleExceptionInternal(e, problem, new HttpHeaders(), HttpStatus.FORBIDDEN, request);
     }
 }

--- a/backend/src/main/java/br/com/calendar/common/exception/ResourceNotFoundException.java
+++ b/backend/src/main/java/br/com/calendar/common/exception/ResourceNotFoundException.java
@@ -1,0 +1,9 @@
+package br.com.calendar.common.exception;
+
+
+public class ResourceNotFoundException extends RuntimeException {
+    
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/br/com/calendar/controller/TaskController.java
+++ b/backend/src/main/java/br/com/calendar/controller/TaskController.java
@@ -1,20 +1,25 @@
 package br.com.calendar.controller;
 
-import br.com.calendar.domain.Task;
-import br.com.calendar.service.TaskService;
-import lombok.AllArgsConstructor;
+import java.time.LocalDate;
+import java.util.List;
+
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import br.com.calendar.domain.Task;
+import br.com.calendar.domain.dto.TaskRequestDTO;
+import br.com.calendar.domain.dto.TaskResponseDTO;
+import br.com.calendar.service.TaskService;
+import lombok.AllArgsConstructor;
 
-import java.time.LocalDate;
-import java.util.List;
 
 @RestController
 @RequestMapping("/tasks")
@@ -40,5 +45,11 @@ public class TaskController {
     @GetMapping("/history")
     public ResponseEntity<List<Task>> getTaskHistory() {
         return ResponseEntity.ok(service.getTaskHistory());
+    }
+    
+    @PatchMapping("/{id}")
+    public ResponseEntity<TaskResponseDTO> updateTask(@PathVariable String id, @RequestBody TaskRequestDTO task) {
+        TaskResponseDTO updatedTask = service.updateTask(task, id);
+        return ResponseEntity.ok(updatedTask);
     }
 }

--- a/backend/src/main/java/br/com/calendar/controller/TaskController.java
+++ b/backend/src/main/java/br/com/calendar/controller/TaskController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -20,7 +21,6 @@ import br.com.calendar.domain.dto.TaskResponseDTO;
 import br.com.calendar.service.TaskService;
 import lombok.AllArgsConstructor;
 
-
 @RestController
 @RequestMapping("/tasks")
 @AllArgsConstructor
@@ -28,11 +28,9 @@ public class TaskController {
 
     private final TaskService service;
 
-
     @GetMapping
     public ResponseEntity<List<Task>> getTasksByDay(
-        @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
-    ) {
+            @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
         return ResponseEntity.ok(service.getTasksForDay(date));
     }
 
@@ -46,10 +44,14 @@ public class TaskController {
     public ResponseEntity<List<Task>> getTaskHistory() {
         return ResponseEntity.ok(service.getTaskHistory());
     }
-    
+
+    @PutMapping("/{id}")
+    public ResponseEntity<TaskResponseDTO> replaceTask(@PathVariable String id, @RequestBody TaskRequestDTO task) {
+        return ResponseEntity.ok(service.updateTask(task, id));
+    }
+
     @PatchMapping("/{id}")
-    public ResponseEntity<TaskResponseDTO> updateTask(@PathVariable String id, @RequestBody TaskRequestDTO task) {
-        TaskResponseDTO updatedTask = service.updateTask(task, id);
-        return ResponseEntity.ok(updatedTask);
+    public ResponseEntity<TaskResponseDTO> patchTask(@PathVariable String id, @RequestBody TaskRequestDTO task) {
+        return ResponseEntity.ok(service.updateTask(task, id));
     }
 }

--- a/backend/src/main/java/br/com/calendar/domain/Task.java
+++ b/backend/src/main/java/br/com/calendar/domain/Task.java
@@ -63,4 +63,7 @@ public class Task extends BaseEntity {
 
     @Column(name = "deleted_at")
     private Instant deletedAt;
+
+    @Column(name = "completed_at")
+    private Instant completedAt;
 }

--- a/backend/src/main/java/br/com/calendar/domain/TaskMapper.java
+++ b/backend/src/main/java/br/com/calendar/domain/TaskMapper.java
@@ -3,8 +3,6 @@ package br.com.calendar.domain;
 import org.springframework.stereotype.Component;
 
 import br.com.calendar.category.Category;
-import br.com.calendar.category.CategoryRepository;
-import br.com.calendar.common.exception.ResourceNotFoundException;
 import br.com.calendar.domain.dto.TaskRequestDTO;
 import br.com.calendar.domain.dto.TaskResponseDTO;
 import lombok.RequiredArgsConstructor;
@@ -13,9 +11,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class TaskMapper {
 
-    private final CategoryRepository categoryRepository;
-
-    public Task toEntity(TaskRequestDTO request) {
+    public Task toEntity(TaskRequestDTO request, Category category) {
         Task task = new Task();
 
         task.setTitle(request.getTitle());
@@ -29,13 +25,8 @@ public class TaskMapper {
         task.setRepeatInterval(request.getRepeatInterval());
         task.setAllDay(request.getAllDay());
         task.setCompletedAt(request.getCompletedAt());
-        
-        if (request.getCategoryId() != null) {
-            Category category = categoryRepository.findById(request.getCategoryId())
-                .orElseThrow(() -> new ResourceNotFoundException("Category not found"));
-            task.setCategory(category);
-        }
-        
+        task.setCategory(category);
+
         return task;
     }
 
@@ -95,11 +86,6 @@ public class TaskMapper {
         }
         if (request.getCompletedAt() != null) {
             task.setCompletedAt(request.getCompletedAt());
-        }
-        if (request.getCategoryId() != null) {
-            Category category = categoryRepository.findById(request.getCategoryId())
-                .orElseThrow(() -> new ResourceNotFoundException("Category not found"));
-            task.setCategory(category);
         }
     }
 }

--- a/backend/src/main/java/br/com/calendar/domain/TaskMapper.java
+++ b/backend/src/main/java/br/com/calendar/domain/TaskMapper.java
@@ -1,0 +1,86 @@
+package br.com.calendar.domain;
+
+import org.springframework.stereotype.Component;
+
+import br.com.calendar.domain.dto.TaskRequestDTO;
+import br.com.calendar.domain.dto.TaskResponseDTO;
+
+@Component
+public class TaskMapper {
+
+    public Task toEntity(TaskRequestDTO request) {
+        Task task = new Task();
+
+        task.setTitle(request.getTitle());
+        task.setDescription(request.getDescription());
+        task.setTimezone(request.getTimezone());
+        task.setLocation(request.getLocation());
+        task.setStatus(request.getStatus());
+        task.setStartsAt(request.getStartsAt());
+        task.setEndsAt(request.getEndsAt());
+        task.setRepeat(request.getRepeat());
+        task.setRepeatInterval(request.getRepeatInterval());
+        task.setAllDay(request.getAllDay());
+        task.setCompletedAt(request.getCompletedAt());
+        return task;
+    }
+
+    public TaskResponseDTO toResponse(Task task) {
+        return TaskResponseDTO.builder()
+                .id(task.getId())
+                .title(task.getTitle())
+                .description(task.getDescription())
+                .timezone(task.getTimezone())
+                .location(task.getLocation())
+                .status(task.getStatus())
+                .startsAt(task.getStartsAt())
+                .endsAt(task.getEndsAt())
+                .repeat(task.getRepeat())
+                .repeatInterval(task.getRepeatInterval())
+                .allDay(task.getAllDay())
+                .categoryId(
+                        task.getCategory() != null
+                                ? task.getCategory().getId()
+                                : null)
+                .createdAt(task.getCreatedAt())
+                .updatedAt(task.getUpdatedAt())
+                .completedAt(task.getCompletedAt())
+                .build();
+    }
+
+    public void updateEntity(Task task, TaskRequestDTO request) {
+        if (request.getTitle() != null) {
+            task.setTitle(request.getTitle());
+        }
+        if (request.getDescription() != null) {
+            task.setDescription(request.getDescription());
+        }
+        if (request.getTimezone() != null) {
+            task.setTimezone(request.getTimezone());
+        }
+        if (request.getLocation() != null) {
+            task.setLocation(request.getLocation());
+        }
+        if (request.getStatus() != null) {
+            task.setStatus(request.getStatus());
+        }
+        if (request.getStartsAt() != null) {
+            task.setStartsAt(request.getStartsAt());
+        }
+        if (request.getEndsAt() != null) {
+            task.setEndsAt(request.getEndsAt());
+        }
+        if (request.getRepeat() != null) {
+            task.setRepeat(request.getRepeat());
+        }
+        if (request.getRepeatInterval() != null) {
+            task.setRepeatInterval(request.getRepeatInterval());
+        }
+        if (request.getAllDay() != null) {
+            task.setAllDay(request.getAllDay());
+        }
+        if (request.getCompletedAt() != null) {
+            task.setCompletedAt(request.getCompletedAt());
+        }
+    }
+}

--- a/backend/src/main/java/br/com/calendar/domain/TaskMapper.java
+++ b/backend/src/main/java/br/com/calendar/domain/TaskMapper.java
@@ -2,11 +2,18 @@ package br.com.calendar.domain;
 
 import org.springframework.stereotype.Component;
 
+import br.com.calendar.category.Category;
+import br.com.calendar.category.CategoryRepository;
+import br.com.calendar.common.exception.ResourceNotFoundException;
 import br.com.calendar.domain.dto.TaskRequestDTO;
 import br.com.calendar.domain.dto.TaskResponseDTO;
+import lombok.RequiredArgsConstructor;
 
 @Component
+@RequiredArgsConstructor
 public class TaskMapper {
+
+    private final CategoryRepository categoryRepository;
 
     public Task toEntity(TaskRequestDTO request) {
         Task task = new Task();
@@ -22,6 +29,13 @@ public class TaskMapper {
         task.setRepeatInterval(request.getRepeatInterval());
         task.setAllDay(request.getAllDay());
         task.setCompletedAt(request.getCompletedAt());
+        
+        if (request.getCategoryId() != null) {
+            Category category = categoryRepository.findById(request.getCategoryId())
+                .orElseThrow(() -> new ResourceNotFoundException("Category not found"));
+            task.setCategory(category);
+        }
+        
         return task;
     }
 
@@ -81,6 +95,11 @@ public class TaskMapper {
         }
         if (request.getCompletedAt() != null) {
             task.setCompletedAt(request.getCompletedAt());
+        }
+        if (request.getCategoryId() != null) {
+            Category category = categoryRepository.findById(request.getCategoryId())
+                .orElseThrow(() -> new ResourceNotFoundException("Category not found"));
+            task.setCategory(category);
         }
     }
 }

--- a/backend/src/main/java/br/com/calendar/domain/dto/TaskRequestDTO.java
+++ b/backend/src/main/java/br/com/calendar/domain/dto/TaskRequestDTO.java
@@ -1,0 +1,35 @@
+package br.com.calendar.domain.dto;
+
+import java.time.Instant;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TaskRequestDTO {
+
+    private String title;
+
+    private String description;
+
+    private String timezone;
+
+    private String location;
+
+    private String status;
+
+    private Instant startsAt;
+
+    private Instant endsAt;
+
+    private Integer repeat;
+
+    private String repeatInterval;
+
+    private Boolean allDay;
+
+    private String categoryId;
+
+    private Instant completedAt;
+}

--- a/backend/src/main/java/br/com/calendar/domain/dto/TaskResponseDTO.java
+++ b/backend/src/main/java/br/com/calendar/domain/dto/TaskResponseDTO.java
@@ -1,0 +1,43 @@
+package br.com.calendar.domain.dto;
+
+import java.time.Instant;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class TaskResponseDTO {
+
+    private String id;
+
+    private String title;
+
+    private String description;
+
+    private String timezone;
+
+    private String location;
+
+    private String status;
+
+    private Instant startsAt;
+
+    private Instant endsAt;
+
+    private Integer repeat;
+
+    private String repeatInterval;
+
+    private Boolean allDay;
+
+    private String categoryId;
+
+    private Instant createdAt;
+
+    private Instant updatedAt;
+
+    private Instant completedAt;
+}

--- a/backend/src/main/java/br/com/calendar/service/TaskService.java
+++ b/backend/src/main/java/br/com/calendar/service/TaskService.java
@@ -46,8 +46,8 @@ public class TaskService {
         return repository.findAll();
     }
 
-    public TaskResponseDTO updateTask(TaskRequestDTO task, String TaskId) {
-        Task existingTask = repository.findById(TaskId)
+    public TaskResponseDTO updateTask(TaskRequestDTO task, String taskId) {
+        Task existingTask = repository.findById(taskId)
                 .orElseThrow(() -> new ResourceNotFoundException("Task not found"));
 
         taskMapper.updateEntity(existingTask, task);

--- a/backend/src/main/java/br/com/calendar/service/TaskService.java
+++ b/backend/src/main/java/br/com/calendar/service/TaskService.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Objects;
 
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -52,8 +53,9 @@ public class TaskService {
                 .orElseThrow(() -> new ResourceNotFoundException("Task not found"));
 
         User currentUser = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        User taskOwner = existingTask.getUser();
 
-        if (currentUser.getId() != existingTask.getUser().getId()) {
+        if (!Objects.equals(currentUser.getId(), taskOwner.getId())) {
             throw new AccessDeniedException("Task does not belong to the current user");
         }
 
@@ -62,4 +64,5 @@ public class TaskService {
         return taskMapper.toResponse(repository.save(existingTask));
 
     }
+    
 }

--- a/backend/src/main/java/br/com/calendar/service/TaskService.java
+++ b/backend/src/main/java/br/com/calendar/service/TaskService.java
@@ -10,6 +10,8 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
+import br.com.calendar.category.Category;
+import br.com.calendar.category.CategoryService;
 import br.com.calendar.common.exception.ResourceNotFoundException;
 import br.com.calendar.domain.Task;
 import br.com.calendar.domain.TaskMapper;
@@ -25,6 +27,7 @@ public class TaskService {
 
     private final TaskRepository repository;
     private final TaskMapper taskMapper;
+    private final CategoryService categoryService;
 
     public Task createTask(Task task) {
         // Get the currently authenticated user from the security context
@@ -59,10 +62,20 @@ public class TaskService {
             throw new AccessDeniedException("Task does not belong to the current user");
         }
 
+        if (!task.getAllDay() && task.getStartsAt().isAfter(task.getEndsAt())) {
+            throw new IllegalArgumentException("Task start time must be before its end time.");
+        }
+
+        String categoryId = task.getCategoryId();
+        if (categoryId != null) {
+            Category category = categoryService.getCategoryOwnedByUser(categoryId, currentUser.getId());
+            existingTask.setCategory(category);
+        }
+
         taskMapper.updateEntity(existingTask, task);
 
         return taskMapper.toResponse(repository.save(existingTask));
 
     }
-    
+
 }

--- a/backend/src/main/java/br/com/calendar/service/TaskService.java
+++ b/backend/src/main/java/br/com/calendar/service/TaskService.java
@@ -5,6 +5,7 @@ import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.util.List;
 
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
@@ -49,6 +50,12 @@ public class TaskService {
     public TaskResponseDTO updateTask(TaskRequestDTO task, String taskId) {
         Task existingTask = repository.findById(taskId)
                 .orElseThrow(() -> new ResourceNotFoundException("Task not found"));
+
+        User currentUser = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        if (currentUser.getId() != existingTask.getUser().getId()) {
+            throw new AccessDeniedException("Task does not belong to the current user");
+        }
 
         taskMapper.updateEntity(existingTask, task);
 

--- a/backend/src/main/java/br/com/calendar/service/TaskService.java
+++ b/backend/src/main/java/br/com/calendar/service/TaskService.java
@@ -1,22 +1,28 @@
 package br.com.calendar.service;
 
-import br.com.calendar.domain.Task;
-import br.com.calendar.domain.TaskRepository;
-import br.com.calendar.user.User;
-import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Service;
-
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.util.List;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+import br.com.calendar.common.exception.ResourceNotFoundException;
+import br.com.calendar.domain.Task;
+import br.com.calendar.domain.TaskMapper;
+import br.com.calendar.domain.TaskRepository;
+import br.com.calendar.domain.dto.TaskRequestDTO;
+import br.com.calendar.domain.dto.TaskResponseDTO;
+import br.com.calendar.user.User;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class TaskService {
 
     private final TaskRepository repository;
+    private final TaskMapper taskMapper;
 
     public Task createTask(Task task) {
         // Get the currently authenticated user from the security context
@@ -33,10 +39,20 @@ public class TaskService {
 
     public void deleteTask(String id) {
         repository.findByIdAndDeletedAtIsNull(id)
-            .ifPresent(task -> repository.deleteById(id));
+                .ifPresent(task -> repository.deleteById(id));
     }
 
     public List<Task> getTaskHistory() {
         return repository.findAll();
+    }
+
+    public TaskResponseDTO updateTask(TaskRequestDTO task, String TaskId) {
+        Task existingTask = repository.findById(TaskId)
+                .orElseThrow(() -> new ResourceNotFoundException("Task not found"));
+
+        taskMapper.updateEntity(existingTask, task);
+
+        return taskMapper.toResponse(repository.save(existingTask));
+
     }
 }

--- a/backend/src/main/java/br/com/calendar/service/TaskService.java
+++ b/backend/src/main/java/br/com/calendar/service/TaskService.java
@@ -56,14 +56,9 @@ public class TaskService {
                 .orElseThrow(() -> new ResourceNotFoundException("Task not found"));
 
         User currentUser = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        User taskOwner = existingTask.getUser();
 
-        if (!Objects.equals(currentUser.getId(), taskOwner.getId())) {
+        if (!Objects.equals(currentUser.getId(), existingTask.getUser().getId())) {
             throw new AccessDeniedException("Task does not belong to the current user");
-        }
-
-        if (!task.getAllDay() && task.getStartsAt().isAfter(task.getEndsAt())) {
-            throw new IllegalArgumentException("Task start time must be before its end time.");
         }
 
         String categoryId = task.getCategoryId();
@@ -74,8 +69,17 @@ public class TaskService {
 
         taskMapper.updateEntity(existingTask, task);
 
-        return taskMapper.toResponse(repository.save(existingTask));
+        validateTaskDates(existingTask);
 
+        return taskMapper.toResponse(repository.save(existingTask));
     }
 
+    private void validateTaskDates(Task task) {
+        boolean allDay = Boolean.TRUE.equals(task.getAllDay());
+
+        if (!allDay && task.getStartsAt() != null && task.getEndsAt() != null
+                && task.getStartsAt().isAfter(task.getEndsAt())) {
+            throw new IllegalArgumentException("Task start time must be before its end time.");
+        }
+    }
 }

--- a/backend/src/main/resources/db/migration/V1__init_schema.sql
+++ b/backend/src/main/resources/db/migration/V1__init_schema.sql
@@ -47,7 +47,8 @@ CREATE TABLE task
     repeat_interval varchar(15),
     all_day         boolean,
     created_at      timestamptz,
-    updated_at      timestamptz
+    updated_at      timestamptz,
+    completed_at    timestamptz
 );
 
 

--- a/backend/src/main/resources/db/migration/V1__init_schema.sql
+++ b/backend/src/main/resources/db/migration/V1__init_schema.sql
@@ -48,7 +48,6 @@ CREATE TABLE task
     all_day         boolean,
     created_at      timestamptz,
     updated_at      timestamptz,
-    completed_at    timestamptz
 );
 
 

--- a/backend/src/main/resources/db/migration/V1__init_schema.sql
+++ b/backend/src/main/resources/db/migration/V1__init_schema.sql
@@ -47,7 +47,7 @@ CREATE TABLE task
     repeat_interval varchar(15),
     all_day         boolean,
     created_at      timestamptz,
-    updated_at      timestamptz,
+    updated_at      timestamptz
 );
 
 

--- a/backend/src/main/resources/db/migration/V9__Add_completed_at_to_task_table.sql
+++ b/backend/src/main/resources/db/migration/V9__Add_completed_at_to_task_table.sql
@@ -1,0 +1,3 @@
+-- Adiciona a coluna completed_at à tabela task, que indica quando a task foi concluída
+ALTER TABLE task
+    ADD COLUMN completed_at TIMESTAMP WITH TIME ZONE;

--- a/backend/src/test/java/br/com/calendar/service/TaskServiceTest.java
+++ b/backend/src/test/java/br/com/calendar/service/TaskServiceTest.java
@@ -1,26 +1,40 @@
 package br.com.calendar.service;
 
-import br.com.calendar.domain.Task;
-import br.com.calendar.domain.TaskMapper;
-import br.com.calendar.domain.TaskRepository;
-import br.com.calendar.domain.dto.TaskRequestDTO;
-import br.com.calendar.domain.dto.TaskResponseDTO;
-import br.com.calendar.user.User;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.access.AccessDeniedException;
 
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import br.com.calendar.category.Category;
+import br.com.calendar.category.CategoryService;
+import br.com.calendar.common.exception.ResourceNotFoundException;
+import br.com.calendar.domain.Task;
+import br.com.calendar.domain.TaskMapper;
+import br.com.calendar.domain.TaskRepository;
+import br.com.calendar.domain.dto.TaskRequestDTO;
+import br.com.calendar.domain.dto.TaskResponseDTO;
+import br.com.calendar.user.User;
 
 @ExtendWith(MockitoExtension.class)
 class TaskServiceTest {
@@ -30,6 +44,8 @@ class TaskServiceTest {
     @Mock
     private TaskMapper taskMapper;
     @Mock
+    private CategoryService categoryService;
+    @Mock
     private SecurityContext securityContext;
     @Mock
     private Authentication authentication;
@@ -37,51 +53,215 @@ class TaskServiceTest {
     @InjectMocks
     private TaskService taskService;
 
+    private static final String TASK_ID = "task123";
+    private static final String USER_ID = "user123";
+
     @BeforeEach
     void setUp() {
         SecurityContextHolder.setContext(securityContext);
     }
 
-    @Test
-    void updateTask_Success() {
-        String taskId = "task123";
+    private TaskRequestDTO validRequest() {
         TaskRequestDTO request = new TaskRequestDTO();
-        Task existingTask = new Task();
+        request.setAllDay(false);
+        request.setStartsAt(Instant.now());
+        request.setEndsAt(Instant.now().plus(1, ChronoUnit.HOURS));
+        return request;
+    }
 
-        User owner = new User();
-        owner.setId(new String("user123")); // objeto distinto, mesmo valor de ID
-        existingTask.setUser(owner);
+    private User userWithId(String id) {
+        User user = new User();
+        user.setId(id);
+        return user;
+    }
 
-        User currentUser = new User();
-        currentUser.setId(new String("user123")); // simula usuário vindo do contexto de autenticação
-
-        when(repository.findById(taskId)).thenReturn(Optional.of(existingTask));
+    private void mockAuthenticatedUser(User user) {
         when(securityContext.getAuthentication()).thenReturn(authentication);
-        when(authentication.getPrincipal()).thenReturn(currentUser);
-        when(repository.save(existingTask)).thenReturn(existingTask);
-        when(taskMapper.toResponse(existingTask)).thenReturn(TaskResponseDTO.builder().build());
-
-        assertNotNull(taskService.updateTask(request, taskId));
+        when(authentication.getPrincipal()).thenReturn(user);
     }
 
     @Test
-    void updateTask_Unauthorized() {
-        String taskId = "task123";
-        String userId = "user123";
-        String wrongUserId = "user456";
-        TaskRequestDTO request = new TaskRequestDTO();
+    void updateTask_Success() {
+        TaskRequestDTO request = validRequest();
+
         Task existingTask = new Task();
-        User user = new User();
-        user.setId(userId);
-        existingTask.setUser(user);
+        existingTask.setUser(userWithId(USER_ID));
 
-        User currentUser = new User();
-        currentUser.setId(wrongUserId);
+        User currentUser = userWithId(USER_ID);
 
-        when(repository.findById(taskId)).thenReturn(Optional.of(existingTask));
-        when(securityContext.getAuthentication()).thenReturn(authentication);
-        when(authentication.getPrincipal()).thenReturn(currentUser);
+        when(repository.findById(TASK_ID)).thenReturn(Optional.of(existingTask));
+        mockAuthenticatedUser(currentUser);
+        when(repository.save(existingTask)).thenReturn(existingTask);
+        when(taskMapper.toResponse(existingTask)).thenReturn(TaskResponseDTO.builder().build());
 
-        assertThrows(AccessDeniedException.class, () -> taskService.updateTask(request, taskId));
+        assertNotNull(taskService.updateTask(request, TASK_ID));
+        verify(taskMapper).updateEntity(existingTask, request);
+    }
+
+    @Test
+    void updateTask_Unauthorized_WhenUserIsNotOwner() {
+        TaskRequestDTO request = validRequest();
+
+        Task existingTask = new Task();
+        existingTask.setUser(userWithId(USER_ID));
+
+        User currentUser = userWithId("user456");
+
+        when(repository.findById(TASK_ID)).thenReturn(Optional.of(existingTask));
+        mockAuthenticatedUser(currentUser);
+
+        assertThrows(AccessDeniedException.class,
+                () -> taskService.updateTask(request, TASK_ID));
+
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    void updateTask_TaskNotFound_ThrowsResourceNotFoundException() {
+        TaskRequestDTO request = validRequest();
+
+        when(repository.findById(TASK_ID)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class,
+                () -> taskService.updateTask(request, TASK_ID));
+
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    void updateTask_PartialUpdate_KeepsExistingDatesValid() {
+        TaskRequestDTO request = new TaskRequestDTO();
+        request.setTitle("Novo título");
+
+        Task existingTask = new Task();
+        existingTask.setUser(userWithId(USER_ID));
+        existingTask.setAllDay(false);
+        existingTask.setStartsAt(Instant.now());
+        existingTask.setEndsAt(Instant.now().plus(1, ChronoUnit.HOURS));
+
+        mockAuthenticatedUser(userWithId(USER_ID));
+        when(repository.findById(TASK_ID)).thenReturn(Optional.of(existingTask));
+        when(repository.save(existingTask)).thenReturn(existingTask);
+        when(taskMapper.toResponse(existingTask)).thenReturn(TaskResponseDTO.builder().build());
+
+        doAnswer(invocation -> {
+            Task t = invocation.getArgument(0);
+            t.setTitle("Novo título"); // simula o merge real do mapper
+            return null;
+        }).when(taskMapper).updateEntity(eq(existingTask), eq(request));
+
+        assertNotNull(taskService.updateTask(request, TASK_ID));
+    }
+
+    @Test
+    void updateTask_PartialUpdate_InvalidatesExistingDates() {
+        // PATCH que muda só o endsAt, tornando o intervalo inválido
+        TaskRequestDTO request = new TaskRequestDTO();
+        request.setEndsAt(Instant.now().minus(1, ChronoUnit.DAYS));
+
+        Task existingTask = new Task();
+        existingTask.setUser(userWithId(USER_ID));
+        existingTask.setAllDay(false);
+        existingTask.setStartsAt(Instant.now());
+        existingTask.setEndsAt(Instant.now().plus(1, ChronoUnit.HOURS));
+
+        mockAuthenticatedUser(userWithId(USER_ID));
+        when(repository.findById(TASK_ID)).thenReturn(Optional.of(existingTask));
+
+        doAnswer(invocation -> {
+            Task t = invocation.getArgument(0);
+            t.setEndsAt(request.getEndsAt()); // simula o merge real
+            return null;
+        }).when(taskMapper).updateEntity(eq(existingTask), eq(request));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> taskService.updateTask(request, TASK_ID));
+
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    void updateTask_AllDayNullOnEntity_TreatedAsNotAllDay() {
+        TaskRequestDTO request = validRequest(); // allDay=false, startsAt antes de endsAt
+
+        Task existingTask = new Task();
+        existingTask.setUser(userWithId(USER_ID));
+        existingTask.setAllDay(null); // estado inconsistente propositalmente
+
+        mockAuthenticatedUser(userWithId(USER_ID));
+        when(repository.findById(TASK_ID)).thenReturn(Optional.of(existingTask));
+
+        doAnswer(invocation -> {
+            Task t = invocation.getArgument(0);
+            t.setAllDay(request.getAllDay());
+            t.setStartsAt(request.getStartsAt());
+            t.setEndsAt(request.getEndsAt());
+            return null;
+        }).when(taskMapper).updateEntity(eq(existingTask), eq(request));
+
+        when(repository.save(existingTask)).thenReturn(existingTask);
+        when(taskMapper.toResponse(existingTask)).thenReturn(TaskResponseDTO.builder().build());
+
+        assertDoesNotThrow(() -> taskService.updateTask(request, TASK_ID));
+    }
+
+    @Test
+    void updateTask_AllDayTrue_SkipsDateValidation() {
+        TaskRequestDTO request = validRequest();
+        request.setAllDay(true);
+        request.setStartsAt(Instant.now());
+        request.setEndsAt(Instant.now().minus(1, ChronoUnit.HOURS)); // seria inválido se allDay=false
+
+        Task existingTask = new Task();
+        existingTask.setUser(userWithId(USER_ID));
+
+        mockAuthenticatedUser(userWithId(USER_ID));
+        when(repository.findById(TASK_ID)).thenReturn(Optional.of(existingTask));
+        when(repository.save(existingTask)).thenReturn(existingTask);
+        when(taskMapper.toResponse(existingTask)).thenReturn(TaskResponseDTO.builder().build());
+
+        assertNotNull(taskService.updateTask(request, TASK_ID));
+    }
+
+    @Test
+    void updateTask_WithCategory_ValidatesOwnershipAndSetsCategory() {
+        TaskRequestDTO request = validRequest();
+        request.setCategoryId("cat123");
+
+        Task existingTask = new Task();
+        existingTask.setUser(userWithId(USER_ID));
+
+        Category category = new Category();
+        category.setId("cat123");
+
+        mockAuthenticatedUser(userWithId(USER_ID));
+        when(repository.findById(TASK_ID)).thenReturn(Optional.of(existingTask));
+        when(categoryService.getCategoryOwnedByUser("cat123", USER_ID)).thenReturn(category);
+        when(repository.save(existingTask)).thenReturn(existingTask);
+        when(taskMapper.toResponse(existingTask)).thenReturn(TaskResponseDTO.builder().build());
+
+        assertNotNull(taskService.updateTask(request, TASK_ID));
+
+        assertEquals(category, existingTask.getCategory());
+        verify(categoryService).getCategoryOwnedByUser("cat123", USER_ID);
+    }
+
+    @Test
+    void updateTask_CategoryNotOwnedByUser_ThrowsAccessDenied() {
+        TaskRequestDTO request = validRequest();
+        request.setCategoryId("cat999");
+
+        Task existingTask = new Task();
+        existingTask.setUser(userWithId(USER_ID));
+
+        mockAuthenticatedUser(userWithId(USER_ID));
+        when(repository.findById(TASK_ID)).thenReturn(Optional.of(existingTask));
+        when(categoryService.getCategoryOwnedByUser("cat999", USER_ID))
+                .thenThrow(new AccessDeniedException("Category does not belong to the current user"));
+
+        assertThrows(AccessDeniedException.class,
+                () -> taskService.updateTask(request, TASK_ID));
+
+        verify(repository, never()).save(any());
     }
 }

--- a/backend/src/test/java/br/com/calendar/service/TaskServiceTest.java
+++ b/backend/src/test/java/br/com/calendar/service/TaskServiceTest.java
@@ -1,0 +1,87 @@
+package br.com.calendar.service;
+
+import br.com.calendar.domain.Task;
+import br.com.calendar.domain.TaskMapper;
+import br.com.calendar.domain.TaskRepository;
+import br.com.calendar.domain.dto.TaskRequestDTO;
+import br.com.calendar.domain.dto.TaskResponseDTO;
+import br.com.calendar.user.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.access.AccessDeniedException;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TaskServiceTest {
+
+    @Mock
+    private TaskRepository repository;
+    @Mock
+    private TaskMapper taskMapper;
+    @Mock
+    private SecurityContext securityContext;
+    @Mock
+    private Authentication authentication;
+
+    @InjectMocks
+    private TaskService taskService;
+
+    @BeforeEach
+    void setUp() {
+        SecurityContextHolder.setContext(securityContext);
+    }
+
+    @Test
+    void updateTask_Success() {
+        String taskId = "task123";
+        TaskRequestDTO request = new TaskRequestDTO();
+        Task existingTask = new Task();
+
+        User owner = new User();
+        owner.setId(new String("user123")); // objeto distinto, mesmo valor de ID
+        existingTask.setUser(owner);
+
+        User currentUser = new User();
+        currentUser.setId(new String("user123")); // simula usuário vindo do contexto de autenticação
+
+        when(repository.findById(taskId)).thenReturn(Optional.of(existingTask));
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        when(authentication.getPrincipal()).thenReturn(currentUser);
+        when(repository.save(existingTask)).thenReturn(existingTask);
+        when(taskMapper.toResponse(existingTask)).thenReturn(TaskResponseDTO.builder().build());
+
+        assertNotNull(taskService.updateTask(request, taskId));
+    }
+
+    @Test
+    void updateTask_Unauthorized() {
+        String taskId = "task123";
+        String userId = "user123";
+        String wrongUserId = "user456";
+        TaskRequestDTO request = new TaskRequestDTO();
+        Task existingTask = new Task();
+        User user = new User();
+        user.setId(userId);
+        existingTask.setUser(user);
+
+        User currentUser = new User();
+        currentUser.setId(wrongUserId);
+
+        when(repository.findById(taskId)).thenReturn(Optional.of(existingTask));
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        when(authentication.getPrincipal()).thenReturn(currentUser);
+
+        assertThrows(AccessDeniedException.class, () -> taskService.updateTask(request, taskId));
+    }
+}


### PR DESCRIPTION
Description
  
  Adds the PATCH /tasks/{id} endpoint to allow partial updates to an existing task. The update payload accepts a category_id as a flat foreign ey (not a nested object). The completed_at field was also added to the Task entity and TaskRequestDTO to support marking a task as completed with a timestamp.
  
  Type of change
  
  - [x] New feature
  - [ ] Bug fix
  - [ ] Refactoring (no behavior change)
  - [ ] Documentation
  - [ ] Infrastructure / CI / CD / Docker
  - [ ] Other:
  
  Affected module(s)
  
  - [x] backend
  - [ ] frontend
  - [ ] desktop
  - [ ] mobile
  - [ ] infra (docker / CI / CD)
  
  How to test
  
  1. Start the application with docker compose up --build or ./mvnw spring-boot:run inside backend/
  2. Open Swagger UI at http://localhost:8080/swagger-ui/index.html
  3. Call PATCH /tasks/{id} with a valid task ID and a partial payload, for example:
  
  {
    "title": "Updated title",
    "categoryId": "your-category-id",
    "completedAt": "2026-08-22T18:00:00Z"
  }
  
  4. Verify the response returns the updated task with the correct values
  
  Checklist
  
  - [ ] I ran the tests locally and they passed
  - [ ] I updated the documentation (README/CONTRIBUTING), if necessary
  - [x] I did not leave any console.log / System.out.println / print debug statements
  - [x] I followed the project's commit convention (Conventional Commits)
  - [x] I reviewed my own diff before opening the PR
  
  Related issue
  [Issue 111](https://github.com/Tecnologia-da-Informacao-BR/Calendar/issues/111)
  Closes #