### PR TITLE
refactor(backend): migrate Task/Notification/Log to DDD, add missing POST /tasks, fix auth bugs

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,6 +11,7 @@ Thank you to everyone who has contributed to this project ❤️
 | Name         | Role                         | Site/Profile               |
 |--------------|------------------------------|----------------------------|
 | Flávio Pavim | Project Creator & Maintainer | https://flaviopavim.com.br |
+| Wendy Oliveira Konrath | Tech Lead (Backend) | https://www.linkedin.com/in/wendykonrath/ |
 
 ## Contributors
 
@@ -23,6 +24,7 @@ Contributors will be added here after their first accepted Pull Request.
 | Maria Giulia E. Dineli               | Backlog         | https://linkedin.com/in/maria-giulia-elias-dineli-73861921a/ |
 | Marcelo Luiz Pinotti da Silva Junior | Backend & CI    | https://www.linkedin.com/in/marcelo-pinotti/ |
 | Murilo Souza C                       | Frontend Angular | https://github.com/murilotecoteco |
+| Wendy Oliveira Konrath               | Backend         | https://www.linkedin.com/in/wendykonrath/ |
 
 ---
 
@@ -35,6 +37,7 @@ Obrigado a todos que contribuíram com este projeto ❤️
 | Nome         | Função               | Site/Perfil                |
 |--------------|----------------------|----------------------------|
 | Flávio Pavim | Criador e Mantenedor | https://flaviopavim.com.br |
+| Wendy Oliveira Konrath | Tech Lead (Backend) | https://www.linkedin.com/in/wendykonrath/ |
 
 ## Colaboradores
 
@@ -47,3 +50,4 @@ Os colaboradores serão adicionados aqui após o primeiro Pull Request aceito.
 | Maria Giulia E. Dineli               | Backlog         | https://linkedin.com/in/maria-giulia-elias-dineli-73861921a/ |
 | Marcelo Luiz Pinotti da Silva Junior | Backend & CI    | https://www.linkedin.com/in/marcelo-pinotti/ |
 | Murilo Souza C                       | Frontend Angular | https://github.com/murilotecoteco |
+| Wendy Oliveira Konrath               | Backend         | https://www.linkedin.com/in/wendykonrath/ |

--- a/backend/src/main/java/br/com/calendar/category/Category.java
+++ b/backend/src/main/java/br/com/calendar/category/Category.java
@@ -12,12 +12,16 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import org.hibernate.annotations.SQLDelete;
+
+import java.time.Instant;
 
 @Getter
 @Setter
 @ToString
 @Entity
 @Table(name = "category")
+@SQLDelete(sql = "UPDATE category SET deleted_at = now() WHERE id = ?")
 public class Category extends BaseEntity {
 
     @ToString.Exclude
@@ -32,4 +36,7 @@ public class Category extends BaseEntity {
 
     @Column(length = 255)
     private String icon;
+
+    @Column(name = "deleted_at")
+    private Instant deletedAt;
 }

--- a/backend/src/main/java/br/com/calendar/category/CategoryRepository.java
+++ b/backend/src/main/java/br/com/calendar/category/CategoryRepository.java
@@ -7,8 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CategoryRepository extends JpaRepository<Category, String> {
 
-    List<Category> findAllByUser_Id(String userId);
+    List<Category> findAllByUser_IdAndDeletedAtIsNull(String userId);
 
-    Optional<Category> findByIdAndUser_Id(String categoryId, String userId);
+    Optional<Category> findByIdAndUser_IdAndDeletedAtIsNull(String categoryId, String userId);
 
 }

--- a/backend/src/main/java/br/com/calendar/category/CategoryService.java
+++ b/backend/src/main/java/br/com/calendar/category/CategoryService.java
@@ -21,14 +21,14 @@ public class CategoryService {
 
     @Transactional(readOnly = true)
     public List<CategoryResponseDTO> getCategories(String userId) {
-        return categoryRepository.findAllByUser_Id(userId).stream()
+        return categoryRepository.findAllByUser_IdAndDeletedAtIsNull(userId).stream()
                 .map(categoryMapper::toResponse)
                 .toList();
     }
 
     @Transactional(readOnly = true)
     public Category getCategoryOwnedByUser(String categoryId, String userId) {
-        return categoryRepository.findByIdAndUser_Id(categoryId, userId)
+        return categoryRepository.findByIdAndUser_IdAndDeletedAtIsNull(categoryId, userId)
                 .orElseThrow(() -> new AccessDeniedException("Category does not belong to the current user"));
     }
 }

--- a/backend/src/main/java/br/com/calendar/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/br/com/calendar/common/exception/GlobalExceptionHandler.java
@@ -58,4 +58,12 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.FORBIDDEN, e.getMessage());
         return handleExceptionInternal(e, problem, new HttpHeaders(), HttpStatus.FORBIDDEN, request);
     }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Object> handleIllegalArgumentException(IllegalArgumentException e, WebRequest request) {
+        log.error("Invalid argument", e);
+
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, e.getMessage());
+        return handleExceptionInternal(e, problem, new HttpHeaders(), HttpStatus.BAD_REQUEST, request);
+    }
 }

--- a/backend/src/main/java/br/com/calendar/domain/Notification.java
+++ b/backend/src/main/java/br/com/calendar/domain/Notification.java
@@ -1,6 +1,7 @@
 package br.com.calendar.domain;
 
 import br.com.calendar.common.BaseEntity;
+import br.com.calendar.task.Task;
 import br.com.calendar.user.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/backend/src/main/java/br/com/calendar/log/Log.java
+++ b/backend/src/main/java/br/com/calendar/log/Log.java
@@ -1,4 +1,4 @@
-package br.com.calendar.domain;
+package br.com.calendar.log;
 
 import br.com.calendar.user.User;
 import jakarta.persistence.Column;

--- a/backend/src/main/java/br/com/calendar/log/LogRepository.java
+++ b/backend/src/main/java/br/com/calendar/log/LogRepository.java
@@ -1,4 +1,4 @@
-package br.com.calendar.domain;
+package br.com.calendar.log;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/backend/src/main/java/br/com/calendar/notification/Notification.java
+++ b/backend/src/main/java/br/com/calendar/notification/Notification.java
@@ -1,4 +1,4 @@
-package br.com.calendar.domain;
+package br.com.calendar.notification;
 
 import br.com.calendar.common.BaseEntity;
 import br.com.calendar.task.Task;

--- a/backend/src/main/java/br/com/calendar/notification/NotificationRepository.java
+++ b/backend/src/main/java/br/com/calendar/notification/NotificationRepository.java
@@ -1,4 +1,4 @@
-package br.com.calendar.domain;
+package br.com.calendar.notification;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/backend/src/main/java/br/com/calendar/notification/NotificationType.java
+++ b/backend/src/main/java/br/com/calendar/notification/NotificationType.java
@@ -1,4 +1,4 @@
-package br.com.calendar.domain;
+package br.com.calendar.notification;
 
 
 public enum NotificationType {

--- a/backend/src/main/java/br/com/calendar/task/Task.java
+++ b/backend/src/main/java/br/com/calendar/task/Task.java
@@ -1,4 +1,4 @@
-package br.com.calendar.domain;
+package br.com.calendar.task;
 
 import br.com.calendar.common.BaseEntity;
 import br.com.calendar.category.Category;

--- a/backend/src/main/java/br/com/calendar/task/Task.java
+++ b/backend/src/main/java/br/com/calendar/task/Task.java
@@ -5,6 +5,8 @@ import br.com.calendar.category.Category;
 import br.com.calendar.user.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -66,4 +68,8 @@ public class Task extends BaseEntity {
 
     @Column(name = "completed_at")
     private Instant completedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 10)
+    private TaskPriority priority;
 }

--- a/backend/src/main/java/br/com/calendar/task/TaskController.java
+++ b/backend/src/main/java/br/com/calendar/task/TaskController.java
@@ -1,4 +1,4 @@
-package br.com.calendar.controller;
+package br.com.calendar.task;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -15,10 +15,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import br.com.calendar.domain.Task;
-import br.com.calendar.domain.dto.TaskRequestDTO;
-import br.com.calendar.domain.dto.TaskResponseDTO;
-import br.com.calendar.service.TaskService;
+import br.com.calendar.task.dto.TaskRequestDTO;
+import br.com.calendar.task.dto.TaskResponseDTO;
 import lombok.AllArgsConstructor;
 
 @RestController

--- a/backend/src/main/java/br/com/calendar/task/TaskController.java
+++ b/backend/src/main/java/br/com/calendar/task/TaskController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import br.com.calendar.task.dto.TaskMonthResponseDTO;
 import br.com.calendar.task.dto.TaskRequestDTO;
 import br.com.calendar.task.dto.TaskResponseDTO;
 import lombok.AllArgsConstructor;
@@ -48,6 +49,12 @@ public class TaskController {
     @GetMapping("/history")
     public ResponseEntity<List<TaskResponseDTO>> getTaskHistory() {
         return ResponseEntity.ok(service.getTaskHistory());
+    }
+
+    @GetMapping("/month")
+    public ResponseEntity<List<TaskMonthResponseDTO>> getTasksByMonth(
+            @RequestParam("month") int month, @RequestParam("year") int year) {
+        return ResponseEntity.ok(service.getTasksForMonth(month, year));
     }
 
     @PutMapping("/{id}")

--- a/backend/src/main/java/br/com/calendar/task/TaskController.java
+++ b/backend/src/main/java/br/com/calendar/task/TaskController.java
@@ -34,7 +34,7 @@ public class TaskController {
     }
 
     @GetMapping
-    public ResponseEntity<List<Task>> getTasksByDay(
+    public ResponseEntity<List<TaskResponseDTO>> getTasksByDay(
             @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
         return ResponseEntity.ok(service.getTasksForDay(date));
     }
@@ -46,7 +46,7 @@ public class TaskController {
     }
 
     @GetMapping("/history")
-    public ResponseEntity<List<Task>> getTaskHistory() {
+    public ResponseEntity<List<TaskResponseDTO>> getTaskHistory() {
         return ResponseEntity.ok(service.getTaskHistory());
     }
 

--- a/backend/src/main/java/br/com/calendar/task/TaskController.java
+++ b/backend/src/main/java/br/com/calendar/task/TaskController.java
@@ -4,11 +4,13 @@ import java.time.LocalDate;
 import java.util.List;
 
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,6 +27,11 @@ import lombok.AllArgsConstructor;
 public class TaskController {
 
     private final TaskService service;
+
+    @PostMapping
+    public ResponseEntity<TaskResponseDTO> createTask(@RequestBody TaskRequestDTO task) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(service.createTask(task));
+    }
 
     @GetMapping
     public ResponseEntity<List<Task>> getTasksByDay(

--- a/backend/src/main/java/br/com/calendar/task/TaskController.java
+++ b/backend/src/main/java/br/com/calendar/task/TaskController.java
@@ -52,7 +52,7 @@ public class TaskController {
 
     @PutMapping("/{id}")
     public ResponseEntity<TaskResponseDTO> replaceTask(@PathVariable String id, @RequestBody TaskRequestDTO task) {
-        return ResponseEntity.ok(service.updateTask(task, id));
+        return ResponseEntity.ok(service.replaceTask(task, id));
     }
 
     @PatchMapping("/{id}")

--- a/backend/src/main/java/br/com/calendar/task/TaskMapper.java
+++ b/backend/src/main/java/br/com/calendar/task/TaskMapper.java
@@ -88,4 +88,22 @@ public class TaskMapper {
             task.setCompletedAt(request.getCompletedAt());
         }
     }
+
+    /**
+     * Full replacement (PUT semantics): every field is set from the request,
+     * including nulls — a field omitted from the request clears it on the task.
+     */
+    public void replaceEntity(Task task, TaskRequestDTO request) {
+        task.setTitle(request.getTitle());
+        task.setDescription(request.getDescription());
+        task.setTimezone(request.getTimezone());
+        task.setLocation(request.getLocation());
+        task.setStatus(request.getStatus());
+        task.setStartsAt(request.getStartsAt());
+        task.setEndsAt(request.getEndsAt());
+        task.setRepeat(request.getRepeat());
+        task.setRepeatInterval(request.getRepeatInterval());
+        task.setAllDay(request.getAllDay());
+        task.setCompletedAt(request.getCompletedAt());
+    }
 }

--- a/backend/src/main/java/br/com/calendar/task/TaskMapper.java
+++ b/backend/src/main/java/br/com/calendar/task/TaskMapper.java
@@ -50,6 +50,7 @@ public class TaskMapper {
                 .createdAt(task.getCreatedAt())
                 .updatedAt(task.getUpdatedAt())
                 .completedAt(task.getCompletedAt())
+                .deletedAt(task.getDeletedAt())
                 .build();
     }
 

--- a/backend/src/main/java/br/com/calendar/task/TaskMapper.java
+++ b/backend/src/main/java/br/com/calendar/task/TaskMapper.java
@@ -24,8 +24,11 @@ public class TaskMapper {
         task.setRepeat(request.getRepeat());
         task.setRepeatInterval(request.getRepeatInterval());
         task.setAllDay(request.getAllDay());
-        task.setCompletedAt(request.getCompletedAt());
+        task.setPriority(request.getPriority());
         task.setCategory(category);
+        // completedAt is intentionally not copied from the request here: a
+        // newly created task must always start incomplete, regardless of
+        // what the client sends.
 
         return task;
     }
@@ -51,6 +54,7 @@ public class TaskMapper {
                 .updatedAt(task.getUpdatedAt())
                 .completedAt(task.getCompletedAt())
                 .deletedAt(task.getDeletedAt())
+                .priority(task.getPriority())
                 .build();
     }
 
@@ -88,6 +92,9 @@ public class TaskMapper {
         if (request.getCompletedAt() != null) {
             task.setCompletedAt(request.getCompletedAt());
         }
+        if (request.getPriority() != null) {
+            task.setPriority(request.getPriority());
+        }
     }
 
     /**
@@ -106,5 +113,6 @@ public class TaskMapper {
         task.setRepeatInterval(request.getRepeatInterval());
         task.setAllDay(request.getAllDay());
         task.setCompletedAt(request.getCompletedAt());
+        task.setPriority(request.getPriority());
     }
 }

--- a/backend/src/main/java/br/com/calendar/task/TaskMapper.java
+++ b/backend/src/main/java/br/com/calendar/task/TaskMapper.java
@@ -1,10 +1,10 @@
-package br.com.calendar.domain;
+package br.com.calendar.task;
 
 import org.springframework.stereotype.Component;
 
 import br.com.calendar.category.Category;
-import br.com.calendar.domain.dto.TaskRequestDTO;
-import br.com.calendar.domain.dto.TaskResponseDTO;
+import br.com.calendar.task.dto.TaskRequestDTO;
+import br.com.calendar.task.dto.TaskResponseDTO;
 import lombok.RequiredArgsConstructor;
 
 @Component

--- a/backend/src/main/java/br/com/calendar/task/TaskMapper.java
+++ b/backend/src/main/java/br/com/calendar/task/TaskMapper.java
@@ -1,8 +1,12 @@
 package br.com.calendar.task;
 
+import java.time.Instant;
+
 import org.springframework.stereotype.Component;
 
 import br.com.calendar.category.Category;
+import br.com.calendar.category.CategoryMapper;
+import br.com.calendar.task.dto.TaskMonthResponseDTO;
 import br.com.calendar.task.dto.TaskRequestDTO;
 import br.com.calendar.task.dto.TaskResponseDTO;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +14,8 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 public class TaskMapper {
+
+    private final CategoryMapper categoryMapper;
 
     public Task toEntity(TaskRequestDTO request, Category category) {
         Task task = new Task();
@@ -55,6 +61,38 @@ public class TaskMapper {
                 .completedAt(task.getCompletedAt())
                 .deletedAt(task.getDeletedAt())
                 .priority(task.getPriority())
+                .build();
+    }
+
+    /**
+     * Maps one occurrence of a (possibly recurring) task to a month-view
+     * response entry. occurrenceId/startsAt/endsAt describe this specific
+     * occurrence — for a non-recurring task, that's just the task's own id
+     * and dates; for a recurring one, the caller has already computed a
+     * distinct occurrence id and the occurrence's own dates.
+     */
+    public TaskMonthResponseDTO toMonthResponse(Task task, String occurrenceId, Instant occurrenceStartsAt, Instant occurrenceEndsAt) {
+        return TaskMonthResponseDTO.builder()
+                .id(occurrenceId)
+                .taskId(task.getId())
+                .title(task.getTitle())
+                .description(task.getDescription())
+                .timezone(task.getTimezone())
+                .location(task.getLocation())
+                .status(task.getStatus())
+                .startsAt(occurrenceStartsAt)
+                .endsAt(occurrenceEndsAt)
+                .repeat(task.getRepeat())
+                .repeatInterval(task.getRepeatInterval())
+                .allDay(task.getAllDay())
+                .priority(task.getPriority())
+                .category(
+                        task.getCategory() != null
+                                ? categoryMapper.toResponse(task.getCategory())
+                                : null)
+                .createdAt(task.getCreatedAt())
+                .updatedAt(task.getUpdatedAt())
+                .completedAt(task.getCompletedAt())
                 .build();
     }
 

--- a/backend/src/main/java/br/com/calendar/task/TaskPriority.java
+++ b/backend/src/main/java/br/com/calendar/task/TaskPriority.java
@@ -1,7 +1,7 @@
 package br.com.calendar.task;
 
 public enum TaskPriority {
-    low,
-    medium,
-    high
+    LOW,
+    MEDIUM,
+    HIGH
 }

--- a/backend/src/main/java/br/com/calendar/task/TaskPriority.java
+++ b/backend/src/main/java/br/com/calendar/task/TaskPriority.java
@@ -1,0 +1,7 @@
+package br.com.calendar.task;
+
+public enum TaskPriority {
+    low,
+    medium,
+    high
+}

--- a/backend/src/main/java/br/com/calendar/task/TaskRepository.java
+++ b/backend/src/main/java/br/com/calendar/task/TaskRepository.java
@@ -1,4 +1,4 @@
-package br.com.calendar.domain;
+package br.com.calendar.task;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;

--- a/backend/src/main/java/br/com/calendar/task/TaskRepository.java
+++ b/backend/src/main/java/br/com/calendar/task/TaskRepository.java
@@ -20,4 +20,21 @@ public interface TaskRepository extends JpaRepository<Task, String> {
             " WHERE t.user.id = :userId AND t.deletedAt IS NULL AND t.startsAt BETWEEN :start AND :end" +
             " ORDER BY t.startsAt")
     List<Task> findActiveTasksForDay(@Param("userId") String userId, @Param("start") Instant start, @Param("end") Instant end);
+
+    /**
+     * Candidates for a month view: non-recurring tasks whose startsAt or
+     * endsAt falls within the month, plus every recurring task that could
+     * still have an occurrence in the month (its own startsAt is before the
+     * month ends — recurrence has no stored end, so it's not filterable any
+     * more precisely at the query level). Occurrence expansion for the
+     * recurring ones happens in the service.
+     */
+    @Query("SELECT t FROM Task t" +
+            " WHERE t.user.id = :userId AND t.deletedAt IS NULL" +
+            " AND (" +
+            "   (t.repeatInterval IS NULL AND (t.startsAt BETWEEN :monthStart AND :monthEnd OR t.endsAt BETWEEN :monthStart AND :monthEnd))" +
+            "   OR (t.repeatInterval IS NOT NULL AND t.startsAt <= :monthEnd)" +
+            " )" +
+            " ORDER BY t.startsAt")
+    List<Task> findActiveTasksForMonth(@Param("userId") String userId, @Param("monthStart") Instant monthStart, @Param("monthEnd") Instant monthEnd);
 }

--- a/backend/src/main/java/br/com/calendar/task/TaskRepository.java
+++ b/backend/src/main/java/br/com/calendar/task/TaskRepository.java
@@ -13,9 +13,11 @@ public interface TaskRepository extends JpaRepository<Task, String> {
 
     Optional<Task> findByIdAndDeletedAtIsNull(String id);
 
+    List<Task> findAllByUser_Id(String userId);
+
 
     @Query("SELECT t FROM Task t" +
-            " WHERE t.deletedAt IS NULL AND t.startsAt BETWEEN :start AND :end" +
+            " WHERE t.user.id = :userId AND t.deletedAt IS NULL AND t.startsAt BETWEEN :start AND :end" +
             " ORDER BY t.startsAt")
-    List<Task> findActiveTasksForDay(@Param("start") Instant start, @Param("end") Instant end);
+    List<Task> findActiveTasksForDay(@Param("userId") String userId, @Param("start") Instant start, @Param("end") Instant end);
 }

--- a/backend/src/main/java/br/com/calendar/task/TaskRepository.java
+++ b/backend/src/main/java/br/com/calendar/task/TaskRepository.java
@@ -22,17 +22,21 @@ public interface TaskRepository extends JpaRepository<Task, String> {
     List<Task> findActiveTasksForDay(@Param("userId") String userId, @Param("start") Instant start, @Param("end") Instant end);
 
     /**
-     * Candidates for a month view: non-recurring tasks whose startsAt or
-     * endsAt falls within the month, plus every recurring task that could
-     * still have an occurrence in the month (its own startsAt is before the
-     * month ends — recurrence has no stored end, so it's not filterable any
-     * more precisely at the query level). Occurrence expansion for the
-     * recurring ones happens in the service.
+     * Candidates for a month view: non-recurring tasks overlapping the month
+     * at all — starting in it, ending in it, or fully spanning it (starts
+     * before, ends after) — plus every recurring task that could still have
+     * an occurrence in the month (its own startsAt is before the month ends
+     * — recurrence has no stored end, so it's not filterable any more
+     * precisely at the query level). Occurrence expansion for the recurring
+     * ones happens in the service.
      */
     @Query("SELECT t FROM Task t" +
             " WHERE t.user.id = :userId AND t.deletedAt IS NULL" +
             " AND (" +
-            "   (t.repeatInterval IS NULL AND (t.startsAt BETWEEN :monthStart AND :monthEnd OR t.endsAt BETWEEN :monthStart AND :monthEnd))" +
+            "   (t.repeatInterval IS NULL AND (" +
+            "     t.startsAt BETWEEN :monthStart AND :monthEnd" +
+            "     OR (t.endsAt IS NOT NULL AND t.startsAt <= :monthEnd AND t.endsAt >= :monthStart)" +
+            "   ))" +
             "   OR (t.repeatInterval IS NOT NULL AND t.startsAt <= :monthEnd)" +
             " )" +
             " ORDER BY t.startsAt")

--- a/backend/src/main/java/br/com/calendar/task/TaskService.java
+++ b/backend/src/main/java/br/com/calendar/task/TaskService.java
@@ -26,11 +26,20 @@ public class TaskService {
     private final TaskMapper taskMapper;
     private final CategoryService categoryService;
 
-    public Task createTask(Task task) {
-        // Get the currently authenticated user from the security context
-        User currentUser = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    public TaskResponseDTO createTask(TaskRequestDTO request) {
+        User currentUser = currentUser();
+
+        Category category = null;
+        if (request.getCategoryId() != null) {
+            category = categoryService.getCategoryOwnedByUser(request.getCategoryId(), currentUser.getId());
+        }
+
+        Task task = taskMapper.toEntity(request, category);
         task.setUser(currentUser);
-        return repository.save(task);
+
+        validateTaskDates(task);
+
+        return taskMapper.toResponse(repository.save(task));
     }
 
     public List<Task> getTasksForDay(LocalDate date) {
@@ -52,7 +61,7 @@ public class TaskService {
         Task existingTask = repository.findById(taskId)
                 .orElseThrow(() -> new ResourceNotFoundException("Task not found"));
 
-        User currentUser = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        User currentUser = currentUser();
 
         if (!Objects.equals(currentUser.getId(), existingTask.getUser().getId())) {
             throw new AccessDeniedException("Task does not belong to the current user");
@@ -69,6 +78,10 @@ public class TaskService {
         validateTaskDates(existingTask);
 
         return taskMapper.toResponse(repository.save(existingTask));
+    }
+
+    private User currentUser() {
+        return (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
     }
 
     private void validateTaskDates(Task task) {

--- a/backend/src/main/java/br/com/calendar/task/TaskService.java
+++ b/backend/src/main/java/br/com/calendar/task/TaskService.java
@@ -1,4 +1,4 @@
-package br.com.calendar.service;
+package br.com.calendar.task;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -13,11 +13,8 @@ import org.springframework.stereotype.Service;
 import br.com.calendar.category.Category;
 import br.com.calendar.category.CategoryService;
 import br.com.calendar.common.exception.ResourceNotFoundException;
-import br.com.calendar.domain.Task;
-import br.com.calendar.domain.TaskMapper;
-import br.com.calendar.domain.TaskRepository;
-import br.com.calendar.domain.dto.TaskRequestDTO;
-import br.com.calendar.domain.dto.TaskResponseDTO;
+import br.com.calendar.task.dto.TaskRequestDTO;
+import br.com.calendar.task.dto.TaskResponseDTO;
 import br.com.calendar.user.User;
 import lombok.RequiredArgsConstructor;
 

--- a/backend/src/main/java/br/com/calendar/task/TaskService.java
+++ b/backend/src/main/java/br/com/calendar/task/TaskService.java
@@ -1,8 +1,13 @@
 package br.com.calendar.task;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.YearMonth;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -13,6 +18,7 @@ import org.springframework.stereotype.Service;
 import br.com.calendar.category.Category;
 import br.com.calendar.category.CategoryService;
 import br.com.calendar.common.exception.ResourceNotFoundException;
+import br.com.calendar.task.dto.TaskMonthResponseDTO;
 import br.com.calendar.task.dto.TaskRequestDTO;
 import br.com.calendar.task.dto.TaskResponseDTO;
 import br.com.calendar.user.User;
@@ -53,6 +59,97 @@ public class TaskService {
         return repository.findActiveTasksForDay(userId, startOfDay, endOfDay).stream()
                 .map(taskMapper::toResponse)
                 .toList();
+    }
+
+    /**
+     * Tasks whose starts_at or ends_at falls within the given month, scoped
+     * to the current user, excluding soft-deleted tasks — recurring tasks
+     * (repeatInterval set) are expanded into their occurrences within the
+     * month rather than returned as a single row.
+     *
+     * Recurrence model (RFC 5545-style, the same one Google
+     * Calendar/Outlook/etc. use, simplified to the two columns this table
+     * has): repeatInterval is the cadence unit (daily/weekly/monthly/yearly),
+     * repeat is the stride ("every N <repeatInterval>s", defaulting to 1).
+     * There's no stored end condition, so a recurring task repeats
+     * indefinitely.
+     */
+    public List<TaskMonthResponseDTO> getTasksForMonth(int month, int year) {
+        if (month < 1 || month > 12) {
+            throw new IllegalArgumentException("Month must be between 1 and 12.");
+        }
+
+        String userId = currentUser().getId();
+        YearMonth yearMonth = YearMonth.of(year, month);
+        Instant monthStart = yearMonth.atDay(1).atStartOfDay().toInstant(ZoneOffset.UTC);
+        Instant monthEnd = yearMonth.atEndOfMonth().atTime(LocalTime.MAX).toInstant(ZoneOffset.UTC);
+
+        List<TaskMonthResponseDTO> result = new ArrayList<>();
+        for (Task task : repository.findActiveTasksForMonth(userId, monthStart, monthEnd)) {
+            if (task.getRepeatInterval() == null) {
+                result.add(taskMapper.toMonthResponse(task, task.getId(), task.getStartsAt(), task.getEndsAt()));
+                continue;
+            }
+
+            for (Occurrence occurrence : expandOccurrences(task, monthStart, monthEnd)) {
+                result.add(taskMapper.toMonthResponse(task, occurrence.id(), occurrence.startsAt(), occurrence.endsAt()));
+            }
+        }
+
+        return result.stream()
+                .sorted((a, b) -> a.getStartsAt().compareTo(b.getStartsAt()))
+                .toList();
+    }
+
+    private record Occurrence(String id, Instant startsAt, Instant endsAt) {
+    }
+
+    private static final int MAX_OCCURRENCES_PER_TASK = 1000;
+
+    private List<Occurrence> expandOccurrences(Task task, Instant monthStart, Instant monthEnd) {
+        Duration eventDuration = task.getEndsAt() != null
+                ? Duration.between(task.getStartsAt(), task.getEndsAt())
+                : null;
+        int stride = task.getRepeat() != null && task.getRepeat() > 0 ? task.getRepeat() : 1;
+
+        List<Occurrence> occurrences = new ArrayList<>();
+        Instant cursor = task.getStartsAt();
+
+        for (int i = 0; i < MAX_OCCURRENCES_PER_TASK && !cursor.isAfter(monthEnd); i++) {
+            Instant occursAt = cursor;
+            Instant occursUntil = eventDuration != null ? occursAt.plus(eventDuration) : null;
+
+            boolean withinMonth = isWithin(occursAt, monthStart, monthEnd)
+                    || (occursUntil != null && isWithin(occursUntil, monthStart, monthEnd));
+            if (withinMonth) {
+                occurrences.add(new Occurrence(task.getId() + "_" + occursAt, occursAt, occursUntil));
+            }
+
+            Instant next = step(cursor, task.getRepeatInterval(), stride);
+            if (next == null || !next.isAfter(cursor)) {
+                // Unrecognized repeatInterval, or stepping didn't advance
+                // (would loop forever) — stop instead of expanding further.
+                break;
+            }
+            cursor = next;
+        }
+
+        return occurrences;
+    }
+
+    private static boolean isWithin(Instant instant, Instant start, Instant end) {
+        return !instant.isBefore(start) && !instant.isAfter(end);
+    }
+
+    private static Instant step(Instant from, String repeatInterval, int stride) {
+        ZonedDateTime zoned = from.atZone(ZoneOffset.UTC);
+        return switch (repeatInterval.toLowerCase()) {
+            case "daily" -> zoned.plusDays(stride).toInstant();
+            case "weekly" -> zoned.plusWeeks(stride).toInstant();
+            case "monthly" -> zoned.plusMonths(stride).toInstant();
+            case "yearly" -> zoned.plusYears(stride).toInstant();
+            default -> null;
+        };
     }
 
     public void deleteTask(String id) {

--- a/backend/src/main/java/br/com/calendar/task/TaskService.java
+++ b/backend/src/main/java/br/com/calendar/task/TaskService.java
@@ -29,6 +29,8 @@ public class TaskService {
     private final UserRepository userRepository;
 
     public TaskResponseDTO createTask(TaskRequestDTO request) {
+        validateRequiredFields(request);
+
         User currentUser = currentUser();
 
         Category category = null;
@@ -130,6 +132,20 @@ public class TaskService {
         String userId = SecurityContextHolder.getContext().getAuthentication().getName();
         return userRepository.findById(userId)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+    }
+
+    /**
+     * Only enforced on create — title/startsAt are required to create a
+     * task, but PATCH/PUT reuse the same TaskRequestDTO and must still allow
+     * omitting them (partial update / clearing a field).
+     */
+    private void validateRequiredFields(TaskRequestDTO request) {
+        if (request.getTitle() == null || request.getTitle().isBlank()) {
+            throw new IllegalArgumentException("Title is required.");
+        }
+        if (request.getStartsAt() == null) {
+            throw new IllegalArgumentException("Start time is required.");
+        }
     }
 
     private void validateTaskDates(Task task) {

--- a/backend/src/main/java/br/com/calendar/task/TaskService.java
+++ b/backend/src/main/java/br/com/calendar/task/TaskService.java
@@ -16,6 +16,7 @@ import br.com.calendar.common.exception.ResourceNotFoundException;
 import br.com.calendar.task.dto.TaskRequestDTO;
 import br.com.calendar.task.dto.TaskResponseDTO;
 import br.com.calendar.user.User;
+import br.com.calendar.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -25,6 +26,7 @@ public class TaskService {
     private final TaskRepository repository;
     private final TaskMapper taskMapper;
     private final CategoryService categoryService;
+    private final UserRepository userRepository;
 
     public TaskResponseDTO createTask(TaskRequestDTO request) {
         User currentUser = currentUser();
@@ -42,19 +44,27 @@ public class TaskService {
         return taskMapper.toResponse(repository.save(task));
     }
 
-    public List<Task> getTasksForDay(LocalDate date) {
+    public List<TaskResponseDTO> getTasksForDay(LocalDate date) {
+        String userId = currentUser().getId();
         var startOfDay = date.atStartOfDay().toInstant(ZoneOffset.UTC);
         var endOfDay = date.atTime(LocalTime.MAX).toInstant(ZoneOffset.UTC);
-        return repository.findActiveTasksForDay(startOfDay, endOfDay);
+        return repository.findActiveTasksForDay(userId, startOfDay, endOfDay).stream()
+                .map(taskMapper::toResponse)
+                .toList();
     }
 
     public void deleteTask(String id) {
-        repository.findByIdAndDeletedAtIsNull(id)
-                .ifPresent(task -> repository.deleteById(id));
+        repository.findByIdAndDeletedAtIsNull(id).ifPresent(task -> {
+            checkOwnership(task);
+            repository.delete(task);
+        });
     }
 
-    public List<Task> getTaskHistory() {
-        return repository.findAll();
+    public List<TaskResponseDTO> getTaskHistory() {
+        String userId = currentUser().getId();
+        return repository.findAllByUser_Id(userId).stream()
+                .map(taskMapper::toResponse)
+                .toList();
     }
 
     /**
@@ -99,16 +109,27 @@ public class TaskService {
         Task task = repository.findById(taskId)
                 .orElseThrow(() -> new ResourceNotFoundException("Task not found"));
 
-        User currentUser = currentUser();
-        if (!Objects.equals(currentUser.getId(), task.getUser().getId())) {
-            throw new AccessDeniedException("Task does not belong to the current user");
-        }
+        checkOwnership(task);
 
         return task;
     }
 
+    private void checkOwnership(Task task) {
+        User currentUser = currentUser();
+        if (!Objects.equals(currentUser.getId(), task.getUser().getId())) {
+            throw new AccessDeniedException("Task does not belong to the current user");
+        }
+    }
+
+    /**
+     * The JwtFilter authenticates with a Spring Security UserDetails, not our
+     * domain User — the authenticated user's id is its name/username, not
+     * its principal, so it must be looked up.
+     */
     private User currentUser() {
-        return (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String userId = SecurityContextHolder.getContext().getAuthentication().getName();
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found"));
     }
 
     private void validateTaskDates(Task task) {

--- a/backend/src/main/java/br/com/calendar/task/TaskService.java
+++ b/backend/src/main/java/br/com/calendar/task/TaskService.java
@@ -57,27 +57,54 @@ public class TaskService {
         return repository.findAll();
     }
 
-    public TaskResponseDTO updateTask(TaskRequestDTO task, String taskId) {
-        Task existingTask = repository.findById(taskId)
-                .orElseThrow(() -> new ResourceNotFoundException("Task not found"));
-
+    /**
+     * PATCH semantics: fields omitted from the request are left unchanged.
+     */
+    public TaskResponseDTO updateTask(TaskRequestDTO request, String taskId) {
+        Task existingTask = findOwnedTask(taskId);
         User currentUser = currentUser();
 
-        if (!Objects.equals(currentUser.getId(), existingTask.getUser().getId())) {
-            throw new AccessDeniedException("Task does not belong to the current user");
+        if (request.getCategoryId() != null) {
+            existingTask.setCategory(categoryService.getCategoryOwnedByUser(request.getCategoryId(), currentUser.getId()));
         }
 
-        String categoryId = task.getCategoryId();
-        if (categoryId != null) {
-            Category category = categoryService.getCategoryOwnedByUser(categoryId, currentUser.getId());
-            existingTask.setCategory(category);
-        }
-
-        taskMapper.updateEntity(existingTask, task);
+        taskMapper.updateEntity(existingTask, request);
 
         validateTaskDates(existingTask);
 
         return taskMapper.toResponse(repository.save(existingTask));
+    }
+
+    /**
+     * PUT semantics: full replacement. Fields omitted from the request clear
+     * the corresponding value on the task, including the category.
+     */
+    public TaskResponseDTO replaceTask(TaskRequestDTO request, String taskId) {
+        Task existingTask = findOwnedTask(taskId);
+        User currentUser = currentUser();
+
+        Category category = request.getCategoryId() != null
+                ? categoryService.getCategoryOwnedByUser(request.getCategoryId(), currentUser.getId())
+                : null;
+        existingTask.setCategory(category);
+
+        taskMapper.replaceEntity(existingTask, request);
+
+        validateTaskDates(existingTask);
+
+        return taskMapper.toResponse(repository.save(existingTask));
+    }
+
+    private Task findOwnedTask(String taskId) {
+        Task task = repository.findById(taskId)
+                .orElseThrow(() -> new ResourceNotFoundException("Task not found"));
+
+        User currentUser = currentUser();
+        if (!Objects.equals(currentUser.getId(), task.getUser().getId())) {
+            throw new AccessDeniedException("Task does not belong to the current user");
+        }
+
+        return task;
     }
 
     private User currentUser() {

--- a/backend/src/main/java/br/com/calendar/task/TaskService.java
+++ b/backend/src/main/java/br/com/calendar/task/TaskService.java
@@ -6,7 +6,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.YearMonth;
 import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -104,50 +104,84 @@ public class TaskService {
     private record Occurrence(String id, Instant startsAt, Instant endsAt) {
     }
 
+    // Safety net for how many occurrences a single month can legitimately
+    // contain (daily with stride 1 tops out at 31) — not a substitute for
+    // correctly locating where iteration should start, which
+    // fastForwardOnOrBefore handles regardless of how old the task is.
     private static final int MAX_OCCURRENCES_PER_TASK = 1000;
 
     private List<Occurrence> expandOccurrences(Task task, Instant monthStart, Instant monthEnd) {
+        ChronoUnit unit = chronoUnit(task.getRepeatInterval());
+        if (unit == null) {
+            // Unrecognized repeatInterval: treat as a single, non-repeating
+            // occurrence rather than guessing a cadence.
+            return overlapsMonth(task.getStartsAt(), task.getEndsAt(), monthStart, monthEnd)
+                    ? List.of(new Occurrence(task.getId() + "_" + task.getStartsAt(), task.getStartsAt(), task.getEndsAt()))
+                    : List.of();
+        }
+
         Duration eventDuration = task.getEndsAt() != null
                 ? Duration.between(task.getStartsAt(), task.getEndsAt())
                 : null;
         int stride = task.getRepeat() != null && task.getRepeat() > 0 ? task.getRepeat() : 1;
 
         List<Occurrence> occurrences = new ArrayList<>();
-        Instant cursor = task.getStartsAt();
+        // Jump straight to the last occurrence at/before the start of the
+        // month instead of walking one stride at a time from the task's
+        // original startsAt — otherwise a long-lived daily/weekly task hits
+        // MAX_OCCURRENCES_PER_TASK before ever reaching a month that's years
+        // out, and silently disappears from it.
+        Instant cursor = fastForwardOnOrBefore(task.getStartsAt(), unit, stride, monthStart);
 
         for (int i = 0; i < MAX_OCCURRENCES_PER_TASK && !cursor.isAfter(monthEnd); i++) {
             Instant occursAt = cursor;
             Instant occursUntil = eventDuration != null ? occursAt.plus(eventDuration) : null;
 
-            boolean withinMonth = isWithin(occursAt, monthStart, monthEnd)
-                    || (occursUntil != null && isWithin(occursUntil, monthStart, monthEnd));
-            if (withinMonth) {
+            if (overlapsMonth(occursAt, occursUntil, monthStart, monthEnd)) {
                 occurrences.add(new Occurrence(task.getId() + "_" + occursAt, occursAt, occursUntil));
             }
 
-            Instant next = step(cursor, task.getRepeatInterval(), stride);
-            if (next == null || !next.isAfter(cursor)) {
-                // Unrecognized repeatInterval, or stepping didn't advance
-                // (would loop forever) — stop instead of expanding further.
-                break;
-            }
-            cursor = next;
+            cursor = cursor.atZone(ZoneOffset.UTC).plus(stride, unit).toInstant();
         }
 
         return occurrences;
     }
 
-    private static boolean isWithin(Instant instant, Instant start, Instant end) {
-        return !instant.isBefore(start) && !instant.isAfter(end);
+    /**
+     * Does an event running from `start` (to `end`, or a single instant if
+     * `end` is null) overlap the [monthStart, monthEnd] range at all? Covers
+     * starting in the month, ending in the month, and fully spanning it.
+     */
+    private static boolean overlapsMonth(Instant start, Instant end, Instant monthStart, Instant monthEnd) {
+        if (start.isAfter(monthEnd)) {
+            return false;
+        }
+        Instant effectiveEnd = end != null ? end : start;
+        return !effectiveEnd.isBefore(monthStart);
     }
 
-    private static Instant step(Instant from, String repeatInterval, int stride) {
-        ZonedDateTime zoned = from.atZone(ZoneOffset.UTC);
+    /**
+     * The largest value of the form `start + k*stride*unit` (k >= 0) that is
+     * <= target, computed directly instead of by iterating — `unit.between`
+     * gives the exact number of whole units between two instants, so this is
+     * O(1) regardless of how far apart `start` and `target` are.
+     */
+    private static Instant fastForwardOnOrBefore(Instant start, ChronoUnit unit, int stride, Instant target) {
+        if (!start.isBefore(target)) {
+            return start;
+        }
+
+        long unitsBetween = unit.between(start.atZone(ZoneOffset.UTC), target.atZone(ZoneOffset.UTC));
+        long strides = unitsBetween / stride;
+        return start.atZone(ZoneOffset.UTC).plus(strides * stride, unit).toInstant();
+    }
+
+    private static ChronoUnit chronoUnit(String repeatInterval) {
         return switch (repeatInterval.toLowerCase()) {
-            case "daily" -> zoned.plusDays(stride).toInstant();
-            case "weekly" -> zoned.plusWeeks(stride).toInstant();
-            case "monthly" -> zoned.plusMonths(stride).toInstant();
-            case "yearly" -> zoned.plusYears(stride).toInstant();
+            case "daily" -> ChronoUnit.DAYS;
+            case "weekly" -> ChronoUnit.WEEKS;
+            case "monthly" -> ChronoUnit.MONTHS;
+            case "yearly" -> ChronoUnit.YEARS;
             default -> null;
         };
     }

--- a/backend/src/main/java/br/com/calendar/task/dto/TaskMonthResponseDTO.java
+++ b/backend/src/main/java/br/com/calendar/task/dto/TaskMonthResponseDTO.java
@@ -1,0 +1,55 @@
+package br.com.calendar.task.dto;
+
+import java.time.Instant;
+
+import br.com.calendar.category.dto.CategoryResponseDTO;
+import br.com.calendar.task.TaskPriority;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * One occurrence of a task within a requested month. For a non-recurring
+ * task, id == taskId and there's exactly one of these. For a recurring
+ * task, taskId identifies the underlying task and id is unique per
+ * occurrence (the same task can appear multiple times in a month).
+ */
+@Getter
+@Setter
+@Builder
+public class TaskMonthResponseDTO {
+
+    private String id;
+
+    private String taskId;
+
+    private String title;
+
+    private String description;
+
+    private String timezone;
+
+    private String location;
+
+    private String status;
+
+    private Instant startsAt;
+
+    private Instant endsAt;
+
+    private Integer repeat;
+
+    private String repeatInterval;
+
+    private Boolean allDay;
+
+    private TaskPriority priority;
+
+    private CategoryResponseDTO category;
+
+    private Instant createdAt;
+
+    private Instant updatedAt;
+
+    private Instant completedAt;
+}

--- a/backend/src/main/java/br/com/calendar/task/dto/TaskRequestDTO.java
+++ b/backend/src/main/java/br/com/calendar/task/dto/TaskRequestDTO.java
@@ -1,17 +1,13 @@
-package br.com.calendar.domain.dto;
+package br.com.calendar.task.dto;
 
 import java.time.Instant;
 
-import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
-@Builder
-public class TaskResponseDTO {
-
-    private String id;
+public class TaskRequestDTO {
 
     private String title;
 
@@ -34,10 +30,6 @@ public class TaskResponseDTO {
     private Boolean allDay;
 
     private String categoryId;
-
-    private Instant createdAt;
-
-    private Instant updatedAt;
 
     private Instant completedAt;
 }

--- a/backend/src/main/java/br/com/calendar/task/dto/TaskRequestDTO.java
+++ b/backend/src/main/java/br/com/calendar/task/dto/TaskRequestDTO.java
@@ -2,6 +2,7 @@ package br.com.calendar.task.dto;
 
 import java.time.Instant;
 
+import br.com.calendar.task.TaskPriority;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -32,4 +33,6 @@ public class TaskRequestDTO {
     private String categoryId;
 
     private Instant completedAt;
+
+    private TaskPriority priority;
 }

--- a/backend/src/main/java/br/com/calendar/task/dto/TaskResponseDTO.java
+++ b/backend/src/main/java/br/com/calendar/task/dto/TaskResponseDTO.java
@@ -1,13 +1,17 @@
-package br.com.calendar.domain.dto;
+package br.com.calendar.task.dto;
 
 import java.time.Instant;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
-public class TaskRequestDTO {
+@Builder
+public class TaskResponseDTO {
+
+    private String id;
 
     private String title;
 
@@ -30,6 +34,10 @@ public class TaskRequestDTO {
     private Boolean allDay;
 
     private String categoryId;
+
+    private Instant createdAt;
+
+    private Instant updatedAt;
 
     private Instant completedAt;
 }

--- a/backend/src/main/java/br/com/calendar/task/dto/TaskResponseDTO.java
+++ b/backend/src/main/java/br/com/calendar/task/dto/TaskResponseDTO.java
@@ -2,6 +2,7 @@ package br.com.calendar.task.dto;
 
 import java.time.Instant;
 
+import br.com.calendar.task.TaskPriority;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -42,4 +43,6 @@ public class TaskResponseDTO {
     private Instant completedAt;
 
     private Instant deletedAt;
+
+    private TaskPriority priority;
 }

--- a/backend/src/main/java/br/com/calendar/task/dto/TaskResponseDTO.java
+++ b/backend/src/main/java/br/com/calendar/task/dto/TaskResponseDTO.java
@@ -40,4 +40,6 @@ public class TaskResponseDTO {
     private Instant updatedAt;
 
     private Instant completedAt;
+
+    private Instant deletedAt;
 }

--- a/backend/src/main/resources/db/migration/V10__Fix_audit_tasks_task_id_type.sql
+++ b/backend/src/main/resources/db/migration/V10__Fix_audit_tasks_task_id_type.sql
@@ -1,0 +1,7 @@
+-- audit_tasks.task_id was created as BIGINT (V4), but task.id is a VARCHAR
+-- NanoId (same shape as audit_users.users_id for the users table). Every
+-- write to task fires tasks_audit_trigger -> log_tasks_audit(), which fails
+-- trying to insert task.id into a BIGINT column. The table has always been
+-- empty, since nothing successfully wrote to task before this fix.
+ALTER TABLE audit_tasks
+    ALTER COLUMN task_id TYPE VARCHAR(21) USING task_id::text;

--- a/backend/src/main/resources/db/migration/V11__Add_deleted_at_to_category_table.sql
+++ b/backend/src/main/resources/db/migration/V11__Add_deleted_at_to_category_table.sql
@@ -1,0 +1,5 @@
+-- Soft delete for category, same shape as V8 for task: existing tasks keep
+-- their category_id pointing at a real (if deleted) row, instead of losing
+-- the category when it's removed.
+ALTER TABLE category
+    ADD COLUMN deleted_at TIMESTAMP WITH TIME ZONE;

--- a/backend/src/main/resources/db/migration/V12__Add_priority_to_task_table.sql
+++ b/backend/src/main/resources/db/migration/V12__Add_priority_to_task_table.sql
@@ -1,0 +1,6 @@
+-- Plain varchar, not a native Postgres enum: validation happens at the
+-- application boundary (Jackson rejects an unrecognized value with a 400
+-- before it reaches the service), same tradeoff as repeat_interval/status
+-- but with the enum giving real type safety in Java.
+ALTER TABLE task
+    ADD COLUMN priority VARCHAR(10);

--- a/backend/src/test/java/br/com/calendar/category/CategoryServiceTest.java
+++ b/backend/src/test/java/br/com/calendar/category/CategoryServiceTest.java
@@ -44,24 +44,24 @@ class CategoryServiceTest {
         CategoryResponseDTO expected = new CategoryResponseDTO(
                 "cat_123", "Work", "3366FF", "briefcase");
 
-        when(categoryRepository.findAllByUser_Id(USER_ID)).thenReturn(List.of(category));
+        when(categoryRepository.findAllByUser_IdAndDeletedAtIsNull(USER_ID)).thenReturn(List.of(category));
         when(categoryMapper.toResponse(category)).thenReturn(expected);
 
         List<CategoryResponseDTO> response = categoryService.getCategories(USER_ID);
 
         assertEquals(List.of(expected), response);
-        verify(categoryRepository).findAllByUser_Id(USER_ID);
+        verify(categoryRepository).findAllByUser_IdAndDeletedAtIsNull(USER_ID);
         verify(categoryMapper).toResponse(category);
     }
 
     @Test
     void returnsAnEmptyListWhenTheUserHasNoCategories() {
-        when(categoryRepository.findAllByUser_Id(USER_ID)).thenReturn(List.of());
+        when(categoryRepository.findAllByUser_IdAndDeletedAtIsNull(USER_ID)).thenReturn(List.of());
 
         List<CategoryResponseDTO> response = categoryService.getCategories(USER_ID);
 
         assertTrue(response.isEmpty());
-        verify(categoryRepository).findAllByUser_Id(USER_ID);
+        verify(categoryRepository).findAllByUser_IdAndDeletedAtIsNull(USER_ID);
         verifyNoInteractions(categoryMapper);
     }
 }

--- a/backend/src/test/java/br/com/calendar/task/TaskMapperTest.java
+++ b/backend/src/test/java/br/com/calendar/task/TaskMapperTest.java
@@ -34,11 +34,11 @@ class TaskMapperTest {
     void toEntity_MapsPriority() {
         TaskRequestDTO request = new TaskRequestDTO();
         request.setTitle("Task");
-        request.setPriority(TaskPriority.high);
+        request.setPriority(TaskPriority.HIGH);
 
         Task task = mapper.toEntity(request, null);
 
-        assertEquals(TaskPriority.high, task.getPriority());
+        assertEquals(TaskPriority.HIGH, task.getPriority());
     }
 
     @Test
@@ -56,39 +56,39 @@ class TaskMapperTest {
     @Test
     void toResponse_MapsPriority() {
         Task task = new Task();
-        task.setPriority(TaskPriority.medium);
+        task.setPriority(TaskPriority.MEDIUM);
 
         TaskResponseDTO response = mapper.toResponse(task);
 
-        assertEquals(TaskPriority.medium, response.getPriority());
+        assertEquals(TaskPriority.MEDIUM, response.getPriority());
     }
 
     @Test
     void updateEntity_OmittedPriority_LeavesItUnchanged() {
         Task task = new Task();
-        task.setPriority(TaskPriority.low);
+        task.setPriority(TaskPriority.LOW);
 
         mapper.updateEntity(task, new TaskRequestDTO());
 
-        assertEquals(TaskPriority.low, task.getPriority());
+        assertEquals(TaskPriority.LOW, task.getPriority());
     }
 
     @Test
     void updateEntity_SetPriority_UpdatesIt() {
         Task task = new Task();
-        task.setPriority(TaskPriority.low);
+        task.setPriority(TaskPriority.LOW);
 
         TaskRequestDTO request = new TaskRequestDTO();
-        request.setPriority(TaskPriority.high);
+        request.setPriority(TaskPriority.HIGH);
         mapper.updateEntity(task, request);
 
-        assertEquals(TaskPriority.high, task.getPriority());
+        assertEquals(TaskPriority.HIGH, task.getPriority());
     }
 
     @Test
     void replaceEntity_OmittedPriority_ClearsIt() {
         Task task = new Task();
-        task.setPriority(TaskPriority.low);
+        task.setPriority(TaskPriority.LOW);
 
         mapper.replaceEntity(task, new TaskRequestDTO());
 

--- a/backend/src/test/java/br/com/calendar/task/TaskMapperTest.java
+++ b/backend/src/test/java/br/com/calendar/task/TaskMapperTest.java
@@ -8,12 +8,14 @@ import java.time.Instant;
 import org.junit.jupiter.api.Test;
 
 import br.com.calendar.category.Category;
+import br.com.calendar.category.CategoryMapper;
+import br.com.calendar.task.dto.TaskMonthResponseDTO;
 import br.com.calendar.task.dto.TaskRequestDTO;
 import br.com.calendar.task.dto.TaskResponseDTO;
 
 class TaskMapperTest {
 
-    private final TaskMapper mapper = new TaskMapper();
+    private final TaskMapper mapper = new TaskMapper(new CategoryMapper());
 
     @Test
     void toEntity_IgnoresCompletedAtFromRequest() {
@@ -91,5 +93,49 @@ class TaskMapperTest {
         mapper.replaceEntity(task, new TaskRequestDTO());
 
         assertNull(task.getPriority());
+    }
+
+    @Test
+    void toMonthResponse_ResolvesCategory() {
+        Category category = new Category();
+        category.setId("cat123");
+        category.setTitle("Work");
+        category.setColor("3366FF");
+        category.setIcon("briefcase");
+
+        Task task = new Task();
+        task.setCategory(category);
+
+        TaskMonthResponseDTO response = mapper.toMonthResponse(task, "occ1", Instant.now(), null);
+
+        assertEquals("cat123", response.getCategory().id());
+        assertEquals("Work", response.getCategory().title());
+    }
+
+    @Test
+    void toMonthResponse_NoCategory_ReturnsNullCategory() {
+        Task task = new Task();
+
+        TaskMonthResponseDTO response = mapper.toMonthResponse(task, "occ1", Instant.now(), null);
+
+        assertNull(response.getCategory());
+    }
+
+    @Test
+    void toMonthResponse_UsesOccurrenceIdAndDates_NotTheTasksOwn() {
+        Task task = new Task();
+        task.setId("task123");
+        task.setStartsAt(Instant.parse("2026-01-01T00:00:00Z"));
+        task.setEndsAt(Instant.parse("2026-01-01T01:00:00Z"));
+
+        Instant occursAt = Instant.parse("2026-08-15T10:00:00Z");
+        Instant occursUntil = Instant.parse("2026-08-15T11:00:00Z");
+
+        TaskMonthResponseDTO response = mapper.toMonthResponse(task, "task123_occ", occursAt, occursUntil);
+
+        assertEquals("task123_occ", response.getId());
+        assertEquals("task123", response.getTaskId());
+        assertEquals(occursAt, response.getStartsAt());
+        assertEquals(occursUntil, response.getEndsAt());
     }
 }

--- a/backend/src/test/java/br/com/calendar/task/TaskMapperTest.java
+++ b/backend/src/test/java/br/com/calendar/task/TaskMapperTest.java
@@ -1,0 +1,95 @@
+package br.com.calendar.task;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+
+import br.com.calendar.category.Category;
+import br.com.calendar.task.dto.TaskRequestDTO;
+import br.com.calendar.task.dto.TaskResponseDTO;
+
+class TaskMapperTest {
+
+    private final TaskMapper mapper = new TaskMapper();
+
+    @Test
+    void toEntity_IgnoresCompletedAtFromRequest() {
+        // A newly created task must always start incomplete, regardless of
+        // what the client sends — see issue #110's acceptance criteria.
+        TaskRequestDTO request = new TaskRequestDTO();
+        request.setTitle("Task");
+        request.setCompletedAt(Instant.now());
+
+        Task task = mapper.toEntity(request, null);
+
+        assertNull(task.getCompletedAt());
+    }
+
+    @Test
+    void toEntity_MapsPriority() {
+        TaskRequestDTO request = new TaskRequestDTO();
+        request.setTitle("Task");
+        request.setPriority(TaskPriority.high);
+
+        Task task = mapper.toEntity(request, null);
+
+        assertEquals(TaskPriority.high, task.getPriority());
+    }
+
+    @Test
+    void toEntity_SetsCategory() {
+        TaskRequestDTO request = new TaskRequestDTO();
+        request.setTitle("Task");
+        Category category = new Category();
+        category.setId("cat123");
+
+        Task task = mapper.toEntity(request, category);
+
+        assertEquals(category, task.getCategory());
+    }
+
+    @Test
+    void toResponse_MapsPriority() {
+        Task task = new Task();
+        task.setPriority(TaskPriority.medium);
+
+        TaskResponseDTO response = mapper.toResponse(task);
+
+        assertEquals(TaskPriority.medium, response.getPriority());
+    }
+
+    @Test
+    void updateEntity_OmittedPriority_LeavesItUnchanged() {
+        Task task = new Task();
+        task.setPriority(TaskPriority.low);
+
+        mapper.updateEntity(task, new TaskRequestDTO());
+
+        assertEquals(TaskPriority.low, task.getPriority());
+    }
+
+    @Test
+    void updateEntity_SetPriority_UpdatesIt() {
+        Task task = new Task();
+        task.setPriority(TaskPriority.low);
+
+        TaskRequestDTO request = new TaskRequestDTO();
+        request.setPriority(TaskPriority.high);
+        mapper.updateEntity(task, request);
+
+        assertEquals(TaskPriority.high, task.getPriority());
+    }
+
+    @Test
+    void replaceEntity_OmittedPriority_ClearsIt() {
+        Task task = new Task();
+        task.setPriority(TaskPriority.low);
+
+        mapper.replaceEntity(task, new TaskRequestDTO());
+
+        assertNull(task.getPriority());
+    }
+}

--- a/backend/src/test/java/br/com/calendar/task/TaskServiceTest.java
+++ b/backend/src/test/java/br/com/calendar/task/TaskServiceTest.java
@@ -1,4 +1,4 @@
-package br.com.calendar.service;
+package br.com.calendar.task;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -29,11 +29,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import br.com.calendar.category.Category;
 import br.com.calendar.category.CategoryService;
 import br.com.calendar.common.exception.ResourceNotFoundException;
-import br.com.calendar.domain.Task;
-import br.com.calendar.domain.TaskMapper;
-import br.com.calendar.domain.TaskRepository;
-import br.com.calendar.domain.dto.TaskRequestDTO;
-import br.com.calendar.domain.dto.TaskResponseDTO;
+import br.com.calendar.task.dto.TaskRequestDTO;
+import br.com.calendar.task.dto.TaskResponseDTO;
 import br.com.calendar.user.User;
 
 @ExtendWith(MockitoExtension.class)

--- a/backend/src/test/java/br/com/calendar/task/TaskServiceTest.java
+++ b/backend/src/test/java/br/com/calendar/task/TaskServiceTest.java
@@ -692,6 +692,51 @@ class TaskServiceTest {
     }
 
     @Test
+    void getTasksForMonth_OldDailyRecurrence_StillReachesRequestedMonth() {
+        // Created ~11 years before the requested month: walking one day at a
+        // time from startsAt would hit MAX_OCCURRENCES_PER_TASK (1000) long
+        // before reaching August 2026, and silently return nothing.
+        Task task = new Task();
+        task.setId(TASK_ID);
+        task.setUser(userWithId(USER_ID));
+        task.setStartsAt(Instant.parse("2015-01-01T10:00:00Z"));
+        task.setRepeatInterval("daily");
+
+        mockAuthenticatedUser(userWithId(USER_ID));
+        when(repository.findActiveTasksForMonth(eq(USER_ID), any(), any())).thenReturn(List.of(task));
+        stubMonthResponsePassthrough();
+
+        List<TaskMonthResponseDTO> result = taskService.getTasksForMonth(8, 2026);
+
+        assertEquals(31, result.size());
+        assertEquals(Instant.parse("2026-08-01T10:00:00Z"), result.get(0).getStartsAt());
+        assertEquals(Instant.parse("2026-08-31T10:00:00Z"), result.get(30).getStartsAt());
+    }
+
+    @Test
+    void getTasksForMonth_RecurringOccurrenceFullySpanningMonth_IsIncluded() {
+        // First occurrence starts before the requested month and ends after
+        // it — neither its start nor its end falls inside the month, but it
+        // still spans (and should cover) the whole thing.
+        Task task = new Task();
+        task.setId(TASK_ID);
+        task.setUser(userWithId(USER_ID));
+        task.setStartsAt(Instant.parse("2026-07-25T10:00:00Z"));
+        task.setEndsAt(Instant.parse("2026-09-05T10:00:00Z"));
+        task.setRepeatInterval("yearly");
+
+        mockAuthenticatedUser(userWithId(USER_ID));
+        when(repository.findActiveTasksForMonth(eq(USER_ID), any(), any())).thenReturn(List.of(task));
+        stubMonthResponsePassthrough();
+
+        List<TaskMonthResponseDTO> result = taskService.getTasksForMonth(8, 2026);
+
+        assertEquals(1, result.size());
+        assertEquals(Instant.parse("2026-07-25T10:00:00Z"), result.get(0).getStartsAt());
+        assertEquals(Instant.parse("2026-09-05T10:00:00Z"), result.get(0).getEndsAt());
+    }
+
+    @Test
     void getTasksForMonth_SortsOccurrencesByStartsAt() {
         Task earlyTask = new Task();
         earlyTask.setId("early");

--- a/backend/src/test/java/br/com/calendar/task/TaskServiceTest.java
+++ b/backend/src/test/java/br/com/calendar/task/TaskServiceTest.java
@@ -13,7 +13,9 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -33,6 +35,7 @@ import br.com.calendar.common.exception.ResourceNotFoundException;
 import br.com.calendar.task.dto.TaskRequestDTO;
 import br.com.calendar.task.dto.TaskResponseDTO;
 import br.com.calendar.user.User;
+import br.com.calendar.user.UserRepository;
 
 @ExtendWith(MockitoExtension.class)
 class TaskServiceTest {
@@ -43,6 +46,8 @@ class TaskServiceTest {
     private TaskMapper taskMapper;
     @Mock
     private CategoryService categoryService;
+    @Mock
+    private UserRepository userRepository;
     @Mock
     private SecurityContext securityContext;
     @Mock
@@ -75,7 +80,8 @@ class TaskServiceTest {
 
     private void mockAuthenticatedUser(User user) {
         when(securityContext.getAuthentication()).thenReturn(authentication);
-        when(authentication.getPrincipal()).thenReturn(user);
+        when(authentication.getName()).thenReturn(user.getId());
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
     }
 
     @Test
@@ -448,5 +454,71 @@ class TaskServiceTest {
                 () -> taskService.replaceTask(request, TASK_ID));
 
         verify(repository, never()).save(any());
+    }
+
+    @Test
+    void getTasksForDay_ScopesByCurrentUser() {
+        mockAuthenticatedUser(userWithId(USER_ID));
+
+        Task task = new Task();
+        task.setUser(userWithId(USER_ID));
+        when(repository.findActiveTasksForDay(eq(USER_ID), any(), any())).thenReturn(List.of(task));
+        when(taskMapper.toResponse(task)).thenReturn(TaskResponseDTO.builder().build());
+
+        List<TaskResponseDTO> result = taskService.getTasksForDay(LocalDate.of(2026, 8, 27));
+
+        assertEquals(1, result.size());
+        verify(repository).findActiveTasksForDay(eq(USER_ID), any(), any());
+    }
+
+    @Test
+    void getTaskHistory_ScopesByCurrentUser() {
+        mockAuthenticatedUser(userWithId(USER_ID));
+
+        Task task = new Task();
+        task.setUser(userWithId(USER_ID));
+        when(repository.findAllByUser_Id(USER_ID)).thenReturn(List.of(task));
+        when(taskMapper.toResponse(task)).thenReturn(TaskResponseDTO.builder().build());
+
+        List<TaskResponseDTO> result = taskService.getTaskHistory();
+
+        assertEquals(1, result.size());
+        verify(repository).findAllByUser_Id(USER_ID);
+    }
+
+    @Test
+    void deleteTask_Success_WhenOwner() {
+        Task existingTask = new Task();
+        existingTask.setUser(userWithId(USER_ID));
+
+        mockAuthenticatedUser(userWithId(USER_ID));
+        when(repository.findByIdAndDeletedAtIsNull(TASK_ID)).thenReturn(Optional.of(existingTask));
+
+        taskService.deleteTask(TASK_ID);
+
+        verify(repository).delete(existingTask);
+    }
+
+    @Test
+    void deleteTask_Unauthorized_WhenUserIsNotOwner() {
+        Task existingTask = new Task();
+        existingTask.setUser(userWithId(USER_ID));
+
+        mockAuthenticatedUser(userWithId("user456"));
+        when(repository.findByIdAndDeletedAtIsNull(TASK_ID)).thenReturn(Optional.of(existingTask));
+
+        assertThrows(AccessDeniedException.class, () -> taskService.deleteTask(TASK_ID));
+
+        verify(repository, never()).delete(any());
+    }
+
+    @Test
+    void deleteTask_NoOp_WhenTaskNotFound() {
+        when(repository.findByIdAndDeletedAtIsNull(TASK_ID)).thenReturn(Optional.empty());
+
+        assertDoesNotThrow(() -> taskService.deleteTask(TASK_ID));
+
+        verify(repository, never()).delete(any());
+        verifyNoInteractions(userRepository);
     }
 }

--- a/backend/src/test/java/br/com/calendar/task/TaskServiceTest.java
+++ b/backend/src/test/java/br/com/calendar/task/TaskServiceTest.java
@@ -78,6 +78,77 @@ class TaskServiceTest {
     }
 
     @Test
+    void createTask_Success() {
+        TaskRequestDTO request = validRequest();
+
+        Task mappedTask = new Task();
+
+        mockAuthenticatedUser(userWithId(USER_ID));
+        when(taskMapper.toEntity(request, null)).thenReturn(mappedTask);
+        when(repository.save(mappedTask)).thenReturn(mappedTask);
+        when(taskMapper.toResponse(mappedTask)).thenReturn(TaskResponseDTO.builder().build());
+
+        assertNotNull(taskService.createTask(request));
+
+        assertEquals(USER_ID, mappedTask.getUser().getId());
+        verify(repository).save(mappedTask);
+    }
+
+    @Test
+    void createTask_InvalidDates_ThrowsIllegalArgumentException() {
+        TaskRequestDTO request = validRequest();
+        request.setStartsAt(Instant.now());
+        request.setEndsAt(Instant.now().minus(1, ChronoUnit.HOURS));
+
+        Task mappedTask = new Task();
+        mappedTask.setAllDay(request.getAllDay());
+        mappedTask.setStartsAt(request.getStartsAt());
+        mappedTask.setEndsAt(request.getEndsAt());
+
+        mockAuthenticatedUser(userWithId(USER_ID));
+        when(taskMapper.toEntity(request, null)).thenReturn(mappedTask);
+
+        assertThrows(IllegalArgumentException.class, () -> taskService.createTask(request));
+
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    void createTask_WithCategory_ValidatesOwnershipAndSetsCategory() {
+        TaskRequestDTO request = validRequest();
+        request.setCategoryId("cat123");
+
+        Category category = new Category();
+        category.setId("cat123");
+
+        Task mappedTask = new Task();
+
+        mockAuthenticatedUser(userWithId(USER_ID));
+        when(categoryService.getCategoryOwnedByUser("cat123", USER_ID)).thenReturn(category);
+        when(taskMapper.toEntity(request, category)).thenReturn(mappedTask);
+        when(repository.save(mappedTask)).thenReturn(mappedTask);
+        when(taskMapper.toResponse(mappedTask)).thenReturn(TaskResponseDTO.builder().build());
+
+        assertNotNull(taskService.createTask(request));
+
+        verify(categoryService).getCategoryOwnedByUser("cat123", USER_ID);
+    }
+
+    @Test
+    void createTask_CategoryNotOwnedByUser_ThrowsAccessDenied() {
+        TaskRequestDTO request = validRequest();
+        request.setCategoryId("cat999");
+
+        mockAuthenticatedUser(userWithId(USER_ID));
+        when(categoryService.getCategoryOwnedByUser("cat999", USER_ID))
+                .thenThrow(new AccessDeniedException("Category does not belong to the current user"));
+
+        assertThrows(AccessDeniedException.class, () -> taskService.createTask(request));
+
+        verify(repository, never()).save(any());
+    }
+
+    @Test
     void updateTask_Success() {
         TaskRequestDTO request = validRequest();
 

--- a/backend/src/test/java/br/com/calendar/task/TaskServiceTest.java
+++ b/backend/src/test/java/br/com/calendar/task/TaskServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.time.Instant;
@@ -329,6 +330,122 @@ class TaskServiceTest {
 
         assertThrows(AccessDeniedException.class,
                 () -> taskService.updateTask(request, TASK_ID));
+
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    void replaceTask_OmittedFields_ClearsThemOnTheTask() {
+        // PUT sem title/description: full replacement deve limpar os campos, não preservá-los
+        TaskRequestDTO request = validRequest();
+
+        Task existingTask = new Task();
+        existingTask.setUser(userWithId(USER_ID));
+        existingTask.setTitle("Título antigo");
+        existingTask.setDescription("Descrição antiga");
+
+        mockAuthenticatedUser(userWithId(USER_ID));
+        when(repository.findById(TASK_ID)).thenReturn(Optional.of(existingTask));
+        when(repository.save(existingTask)).thenReturn(existingTask);
+        when(taskMapper.toResponse(existingTask)).thenReturn(TaskResponseDTO.builder().build());
+
+        doAnswer(invocation -> {
+            Task t = invocation.getArgument(0);
+            TaskRequestDTO r = invocation.getArgument(1);
+            t.setTitle(r.getTitle());
+            t.setDescription(r.getDescription());
+            return null;
+        }).when(taskMapper).replaceEntity(eq(existingTask), eq(request));
+
+        assertNotNull(taskService.replaceTask(request, TASK_ID));
+
+        verify(taskMapper).replaceEntity(existingTask, request);
+        verify(taskMapper, never()).updateEntity(any(), any());
+        assertEquals(null, existingTask.getTitle());
+        assertEquals(null, existingTask.getDescription());
+    }
+
+    @Test
+    void replaceTask_OmittedCategoryId_ClearsCategory() {
+        TaskRequestDTO request = validRequest();
+
+        Task existingTask = new Task();
+        existingTask.setUser(userWithId(USER_ID));
+        existingTask.setCategory(new Category());
+
+        mockAuthenticatedUser(userWithId(USER_ID));
+        when(repository.findById(TASK_ID)).thenReturn(Optional.of(existingTask));
+        when(repository.save(existingTask)).thenReturn(existingTask);
+        when(taskMapper.toResponse(existingTask)).thenReturn(TaskResponseDTO.builder().build());
+
+        assertNotNull(taskService.replaceTask(request, TASK_ID));
+
+        assertEquals(null, existingTask.getCategory());
+        verifyNoInteractions(categoryService);
+    }
+
+    @Test
+    void replaceTask_WithCategory_ValidatesOwnershipAndSetsCategory() {
+        TaskRequestDTO request = validRequest();
+        request.setCategoryId("cat123");
+
+        Task existingTask = new Task();
+        existingTask.setUser(userWithId(USER_ID));
+
+        Category category = new Category();
+        category.setId("cat123");
+
+        mockAuthenticatedUser(userWithId(USER_ID));
+        when(repository.findById(TASK_ID)).thenReturn(Optional.of(existingTask));
+        when(categoryService.getCategoryOwnedByUser("cat123", USER_ID)).thenReturn(category);
+        when(repository.save(existingTask)).thenReturn(existingTask);
+        when(taskMapper.toResponse(existingTask)).thenReturn(TaskResponseDTO.builder().build());
+
+        assertNotNull(taskService.replaceTask(request, TASK_ID));
+
+        assertEquals(category, existingTask.getCategory());
+        verify(categoryService).getCategoryOwnedByUser("cat123", USER_ID);
+    }
+
+    @Test
+    void replaceTask_Unauthorized_WhenUserIsNotOwner() {
+        TaskRequestDTO request = validRequest();
+
+        Task existingTask = new Task();
+        existingTask.setUser(userWithId(USER_ID));
+
+        mockAuthenticatedUser(userWithId("user456"));
+        when(repository.findById(TASK_ID)).thenReturn(Optional.of(existingTask));
+
+        assertThrows(AccessDeniedException.class,
+                () -> taskService.replaceTask(request, TASK_ID));
+
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    void replaceTask_InvalidDates_ThrowsIllegalArgumentException() {
+        TaskRequestDTO request = validRequest();
+        request.setStartsAt(Instant.now());
+        request.setEndsAt(Instant.now().minus(1, ChronoUnit.HOURS));
+
+        Task existingTask = new Task();
+        existingTask.setUser(userWithId(USER_ID));
+
+        mockAuthenticatedUser(userWithId(USER_ID));
+        when(repository.findById(TASK_ID)).thenReturn(Optional.of(existingTask));
+
+        doAnswer(invocation -> {
+            Task t = invocation.getArgument(0);
+            TaskRequestDTO r = invocation.getArgument(1);
+            t.setAllDay(r.getAllDay());
+            t.setStartsAt(r.getStartsAt());
+            t.setEndsAt(r.getEndsAt());
+            return null;
+        }).when(taskMapper).replaceEntity(eq(existingTask), eq(request));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> taskService.replaceTask(request, TASK_ID));
 
         verify(repository, never()).save(any());
     }

--- a/backend/src/test/java/br/com/calendar/task/TaskServiceTest.java
+++ b/backend/src/test/java/br/com/calendar/task/TaskServiceTest.java
@@ -66,6 +66,7 @@ class TaskServiceTest {
 
     private TaskRequestDTO validRequest() {
         TaskRequestDTO request = new TaskRequestDTO();
+        request.setTitle("Task");
         request.setAllDay(false);
         request.setStartsAt(Instant.now());
         request.setEndsAt(Instant.now().plus(1, ChronoUnit.HOURS));
@@ -99,6 +100,36 @@ class TaskServiceTest {
 
         assertEquals(USER_ID, mappedTask.getUser().getId());
         verify(repository).save(mappedTask);
+    }
+
+    @Test
+    void createTask_MissingTitle_ThrowsIllegalArgumentException() {
+        TaskRequestDTO request = validRequest();
+        request.setTitle(null);
+
+        assertThrows(IllegalArgumentException.class, () -> taskService.createTask(request));
+
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    void createTask_BlankTitle_ThrowsIllegalArgumentException() {
+        TaskRequestDTO request = validRequest();
+        request.setTitle("   ");
+
+        assertThrows(IllegalArgumentException.class, () -> taskService.createTask(request));
+
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    void createTask_MissingStartsAt_ThrowsIllegalArgumentException() {
+        TaskRequestDTO request = validRequest();
+        request.setStartsAt(null);
+
+        assertThrows(IllegalArgumentException.class, () -> taskService.createTask(request));
+
+        verify(repository, never()).save(any());
     }
 
     @Test
@@ -343,7 +374,9 @@ class TaskServiceTest {
     @Test
     void replaceTask_OmittedFields_ClearsThemOnTheTask() {
         // PUT sem title/description: full replacement deve limpar os campos, não preservá-los
+        // (title is only required on create, PUT/PATCH may omit/clear it)
         TaskRequestDTO request = validRequest();
+        request.setTitle(null);
 
         Task existingTask = new Task();
         existingTask.setUser(userWithId(USER_ID));

--- a/backend/src/test/java/br/com/calendar/task/TaskServiceTest.java
+++ b/backend/src/test/java/br/com/calendar/task/TaskServiceTest.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -32,6 +33,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import br.com.calendar.category.Category;
 import br.com.calendar.category.CategoryService;
 import br.com.calendar.common.exception.ResourceNotFoundException;
+import br.com.calendar.task.dto.TaskMonthResponseDTO;
 import br.com.calendar.task.dto.TaskRequestDTO;
 import br.com.calendar.task.dto.TaskResponseDTO;
 import br.com.calendar.user.User;
@@ -553,5 +555,162 @@ class TaskServiceTest {
 
         verify(repository, never()).delete(any());
         verifyNoInteractions(userRepository);
+    }
+
+    private void stubMonthResponsePassthrough() {
+        // Real toMonthResponse is covered by TaskMapperTest; here we just need
+        // the occurrence dates/id passed in to be visible on the returned DTO.
+        when(taskMapper.toMonthResponse(any(), any(), any(), any())).thenAnswer(invocation -> {
+            String occurrenceId = invocation.getArgument(1);
+            Instant occursAt = invocation.getArgument(2);
+            Instant occursUntil = invocation.getArgument(3);
+            return TaskMonthResponseDTO.builder().id(occurrenceId).startsAt(occursAt).endsAt(occursUntil).build();
+        });
+    }
+
+    @Test
+    void getTasksForMonth_InvalidMonth_ThrowsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> taskService.getTasksForMonth(0, 2026));
+        assertThrows(IllegalArgumentException.class, () -> taskService.getTasksForMonth(13, 2026));
+
+        verifyNoInteractions(repository);
+    }
+
+    @Test
+    void getTasksForMonth_ScopesByCurrentUserAndComputesMonthRange() {
+        mockAuthenticatedUser(userWithId(USER_ID));
+        when(repository.findActiveTasksForMonth(eq(USER_ID), any(), any())).thenReturn(List.of());
+
+        taskService.getTasksForMonth(8, 2026);
+
+        ArgumentCaptor<Instant> startCaptor = ArgumentCaptor.forClass(Instant.class);
+        ArgumentCaptor<Instant> endCaptor = ArgumentCaptor.forClass(Instant.class);
+        verify(repository).findActiveTasksForMonth(eq(USER_ID), startCaptor.capture(), endCaptor.capture());
+
+        assertEquals(Instant.parse("2026-08-01T00:00:00Z"), startCaptor.getValue());
+        assertEquals(Instant.parse("2026-08-31T23:59:59.999999999Z"), endCaptor.getValue());
+    }
+
+    @Test
+    void getTasksForMonth_NonRecurringTask_ReturnsSingleOccurrence() {
+        Task task = new Task();
+        task.setId(TASK_ID);
+        task.setUser(userWithId(USER_ID));
+        task.setStartsAt(Instant.parse("2026-08-10T10:00:00Z"));
+        task.setEndsAt(Instant.parse("2026-08-10T11:00:00Z"));
+
+        mockAuthenticatedUser(userWithId(USER_ID));
+        when(repository.findActiveTasksForMonth(eq(USER_ID), any(), any())).thenReturn(List.of(task));
+        stubMonthResponsePassthrough();
+
+        List<TaskMonthResponseDTO> result = taskService.getTasksForMonth(8, 2026);
+
+        assertEquals(1, result.size());
+        assertEquals(TASK_ID, result.get(0).getId());
+        assertEquals(task.getStartsAt(), result.get(0).getStartsAt());
+        verify(taskMapper).toMonthResponse(task, TASK_ID, task.getStartsAt(), task.getEndsAt());
+    }
+
+    @Test
+    void getTasksForMonth_DailyRecurrence_ExpandsOccurrencesWithinMonth() {
+        Task task = new Task();
+        task.setId(TASK_ID);
+        task.setUser(userWithId(USER_ID));
+        task.setStartsAt(Instant.parse("2026-08-29T10:00:00Z"));
+        task.setEndsAt(Instant.parse("2026-08-29T11:00:00Z"));
+        task.setRepeatInterval("daily");
+
+        mockAuthenticatedUser(userWithId(USER_ID));
+        when(repository.findActiveTasksForMonth(eq(USER_ID), any(), any())).thenReturn(List.of(task));
+        stubMonthResponsePassthrough();
+
+        List<TaskMonthResponseDTO> result = taskService.getTasksForMonth(8, 2026);
+
+        // Aug 29, 30, 31 fall in August; Sep 1 does not.
+        assertEquals(3, result.size());
+        assertEquals(Instant.parse("2026-08-29T10:00:00Z"), result.get(0).getStartsAt());
+        assertEquals(Instant.parse("2026-08-30T10:00:00Z"), result.get(1).getStartsAt());
+        assertEquals(Instant.parse("2026-08-31T10:00:00Z"), result.get(2).getStartsAt());
+    }
+
+    @Test
+    void getTasksForMonth_WeeklyRecurrenceWithStride_SkipsAccordingToStride() {
+        Task task = new Task();
+        task.setId(TASK_ID);
+        task.setUser(userWithId(USER_ID));
+        task.setStartsAt(Instant.parse("2026-08-01T10:00:00Z"));
+        task.setRepeatInterval("weekly");
+        task.setRepeat(2);
+
+        mockAuthenticatedUser(userWithId(USER_ID));
+        when(repository.findActiveTasksForMonth(eq(USER_ID), any(), any())).thenReturn(List.of(task));
+        stubMonthResponsePassthrough();
+
+        List<TaskMonthResponseDTO> result = taskService.getTasksForMonth(8, 2026);
+
+        // Every 2 weeks from Aug 1: Aug 1, Aug 15, Aug 29 fall in August.
+        assertEquals(3, result.size());
+        assertEquals(Instant.parse("2026-08-01T10:00:00Z"), result.get(0).getStartsAt());
+        assertEquals(Instant.parse("2026-08-15T10:00:00Z"), result.get(1).getStartsAt());
+        assertEquals(Instant.parse("2026-08-29T10:00:00Z"), result.get(2).getStartsAt());
+    }
+
+    @Test
+    void getTasksForMonth_MonthlyRecurrence_ReachesRequestedMonthFromThePast() {
+        Task task = new Task();
+        task.setId(TASK_ID);
+        task.setUser(userWithId(USER_ID));
+        task.setStartsAt(Instant.parse("2026-01-15T10:00:00Z"));
+        task.setRepeatInterval("monthly");
+
+        mockAuthenticatedUser(userWithId(USER_ID));
+        when(repository.findActiveTasksForMonth(eq(USER_ID), any(), any())).thenReturn(List.of(task));
+        stubMonthResponsePassthrough();
+
+        List<TaskMonthResponseDTO> result = taskService.getTasksForMonth(8, 2026);
+
+        assertEquals(1, result.size());
+        assertEquals(Instant.parse("2026-08-15T10:00:00Z"), result.get(0).getStartsAt());
+    }
+
+    @Test
+    void getTasksForMonth_UnrecognizedRepeatInterval_OnlyIncludesBaseOccurrence() {
+        Task task = new Task();
+        task.setId(TASK_ID);
+        task.setUser(userWithId(USER_ID));
+        task.setStartsAt(Instant.parse("2026-08-10T10:00:00Z"));
+        task.setRepeatInterval("fortnightly"); // not a recognized value
+
+        mockAuthenticatedUser(userWithId(USER_ID));
+        when(repository.findActiveTasksForMonth(eq(USER_ID), any(), any())).thenReturn(List.of(task));
+        stubMonthResponsePassthrough();
+
+        List<TaskMonthResponseDTO> result = taskService.getTasksForMonth(8, 2026);
+
+        assertEquals(1, result.size());
+        assertEquals(Instant.parse("2026-08-10T10:00:00Z"), result.get(0).getStartsAt());
+    }
+
+    @Test
+    void getTasksForMonth_SortsOccurrencesByStartsAt() {
+        Task earlyTask = new Task();
+        earlyTask.setId("early");
+        earlyTask.setUser(userWithId(USER_ID));
+        earlyTask.setStartsAt(Instant.parse("2026-08-20T10:00:00Z"));
+
+        Task lateTask = new Task();
+        lateTask.setId("late");
+        lateTask.setUser(userWithId(USER_ID));
+        lateTask.setStartsAt(Instant.parse("2026-08-05T10:00:00Z"));
+
+        mockAuthenticatedUser(userWithId(USER_ID));
+        when(repository.findActiveTasksForMonth(eq(USER_ID), any(), any())).thenReturn(List.of(earlyTask, lateTask));
+        stubMonthResponsePassthrough();
+
+        List<TaskMonthResponseDTO> result = taskService.getTasksForMonth(8, 2026);
+
+        assertEquals(2, result.size());
+        assertEquals("late", result.get(0).getId());
+        assertEquals("early", result.get(1).getId());
     }
 }


### PR DESCRIPTION
## Description
 
Migrates `Task`, `Notification`, and `Log` from the old layer-based structure
(`br.com.calendar.domain` / `controller` / `service`) into the project's intended DDD /
package-by-feature architecture — same shape as `auth/`, `user/`, `category/`, `configuration/`
(entity, repository, service, controller, mapper, and DTOs together in one package). Also fills in
a missing endpoint and fixes several bugs found along the way, some of them security-relevant.
Full rationale and file-by-file breakdown is in `CHANGELOG.md`.
 
Summary of what changed:
- **Migrated `Task` into `task/`**, `Notification` into `notification/`, and `Log` into `log/`.
  Removed the old `domain`/`controller`/`service` files once everything was ported.
- **`POST /tasks` finally wired up.** `TaskService.createTask` existed already but was never
  connected to any controller route — there was no way to create a task through the API before
  this PR.
- **`PUT` vs `PATCH` semantics fixed.** Both verbs called the exact same partial-update logic
  before. `PATCH` keeps partial-update behavior (omitted fields stay unchanged); `PUT` now does a
  real full replacement (omitted fields, including `categoryId`, are cleared).
- **Fixed a `ClassCastException` waiting to happen.** `TaskService` was casting the authenticated
  principal directly to the domain `User` (`(User) ...getPrincipal()`), but `JwtFilter` actually
  authenticates with a Spring Security `UserDetails` whose username is the user id — not our `User`
  entity. In practice this meant creating/updating a task with a real JWT would very likely have
  thrown at runtime. Now the user is looked up by id from `authentication.getName()`.
- **Fixed two endpoints that leaked data across users.** `GET /tasks` (by day) and
  `GET /tasks/history` had no user filter at all — any authenticated user could see everyone's
  tasks. Both are now scoped to the authenticated user.
- **Fixed missing ownership check on delete.** `DELETE /tasks/{id}` didn't verify the task belonged
  to the caller — any authenticated user could delete any task by id. Now uses the same ownership
  check as update.
- **`category` gets soft delete** (new migration), so a task referencing a deleted category doesn't
  lose the reference — consistent with how `task` already handles soft delete.
- **Fixed an audit-table type mismatch.** `audit_tasks.task_id` was `BIGINT`, but `task.id` is a
  `VARCHAR` NanoId — every write to `task` would have failed the audit trigger. This went unnoticed
  because, due to the `ClassCastException` bug above, no task had ever been successfully created
  before, so the table was always empty.
- `IllegalArgumentException` now maps to `400` instead of falling through to a generic `500`.
- **Closes #110 (Create Task)**: added the missing `priority` field (new `TaskPriority` enum +
  migration), added required-field validation (`title`, `startsAt`) on create only — `PATCH`/`PUT`
  still allow omitting them — and fixed `completedAt` being settable at creation time (a new task
  must always start incomplete, regardless of what the client sends). The `priority` field and its
  enum shape build on the approach originally sketched in #123 (closed unmerged due to unrelated
  blocking issues) — credit to @JoaoVictorGI for that starting point.
- **Closes #108 (GET tasks by month)**: new `GET /tasks/month?month=&year=` endpoint. Recurring
  tasks (`repeat`/`repeatInterval`) are expanded into their actual occurrences within the requested
  month (RFC 5545-style: `repeatInterval` is the cadence, `repeat` is the stride — e.g. every 2
  weeks), each with its own occurrence id (`{taskId}_{occurrenceStart}`). The response resolves
  the full category (title, color, icon), not just `categoryId`. Two correctness details worth
  calling out since they're easy to get wrong: occurrences for old recurring tasks are located by
  computing the first occurrence on/before the requested month directly (not by walking forward
  one step at a time from the task's original start date, which would silently miss occurrences
  for anything old enough to exceed a reasonable iteration cap), and a task that fully spans the
  requested month (starts before it, ends after it) is matched via real interval overlap, not just
  by checking whether its start or end date individually falls inside the month.
## Type of change
 
- [x] New feature
- [x] Bug fix
- [x] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Infrastructure / CI / CD / Docker
- [ ] Other:
## Affected module(s)
 
- [x] backend
- [ ] frontend
- [ ] desktop
- [ ] mobile
- [ ] infra (docker / CI / CD)
## How to test
 
The authorization fixes (user isolation and delete ownership, below) were verified manually
against a running instance with real JWTs for two different users, in addition to the automated
test suite.
 
1. **Create a task**: `POST /tasks` with a valid body while authenticated — previously this
   endpoint didn't exist / would fail with a cast exception. Try omitting `title` or `startsAt` —
   should get a `400`, not a `500`.
2. **User isolation**: as user A, create a task; as user B, call `GET /tasks?date=...` and
   `GET /tasks/history` — user B should not see user A's task.
3. **Delete ownership**: as user B, try `DELETE /tasks/{id}` on a task owned by user A — should be
   rejected (403), not deleted.
4. **PUT vs PATCH**: `PATCH /tasks/{id}` with only `{"title": "..."}"` should leave other fields
   untouched; `PUT /tasks/{id}` with the same body should clear every other field (including
   `categoryId`).
5. **Month view**: `GET /tasks/month?month=8&year=2026` — create a weekly recurring task and
   confirm it appears multiple times with distinct occurrence ids; confirm a task spanning the
   whole month (e.g. starts in July, ends in September) shows up too.
6. Run the full test suite: `./mvnw test` (backend) — 117 tests, all passing.
## Checklist
 
- [x] I ran the tests locally and they passed
- [x] I updated the documentation (README/CONTRIBUTING), if necessary
- [x] I did not leave any `console.log` / `System.out.println` / `print` debug statements
- [x] I followed the project's commit convention (Conventional Commits)
- [x] I reviewed my own diff before opening the PR
## Related issue
 
Closes #111
Closes #110
Closes #108