### PR TITLE
feat: add category creation endpoint

### DIFF
--- a/backend/src/main/java/br/com/calendar/category/CategoryController.java
+++ b/backend/src/main/java/br/com/calendar/category/CategoryController.java
@@ -3,6 +3,7 @@ package br.com.calendar.category;
 import br.com.calendar.category.dto.CategoryRequestDTO;
 import br.com.calendar.category.dto.CategoryResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -28,7 +29,7 @@ public class CategoryController {
     @Operation(summary = "Create a category for the authenticated user")
     @PostMapping
     public ResponseEntity<CategoryResponseDTO> createCategory(
-            @RequestBody CategoryRequestDTO request, Authentication authentication) {
+            @Valid @RequestBody CategoryRequestDTO request, Authentication authentication) {
         String userId = authenticatedUserId(authentication);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(categoryService.createCategory(request, userId));

--- a/backend/src/main/java/br/com/calendar/category/CategoryController.java
+++ b/backend/src/main/java/br/com/calendar/category/CategoryController.java
@@ -1,11 +1,14 @@
 package br.com.calendar.category;
 
+import br.com.calendar.category.dto.CategoryRequestDTO;
 import br.com.calendar.category.dto.CategoryResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
@@ -22,13 +25,26 @@ public class CategoryController {
         this.categoryService = categoryService;
     }
 
+    @Operation(summary = "Create a category for the authenticated user")
+    @PostMapping
+    public ResponseEntity<CategoryResponseDTO> createCategory(
+            @RequestBody CategoryRequestDTO request, Authentication authentication) {
+        String userId = authenticatedUserId(authentication);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(categoryService.createCategory(request, userId));
+    }
+
     @Operation(summary = "Get the authenticated user's categories")
     @GetMapping
     public ResponseEntity<List<CategoryResponseDTO>> getCategories(Authentication authentication) {
+        return ResponseEntity.ok(categoryService.getCategories(authenticatedUserId(authentication)));
+    }
+
+    private String authenticatedUserId(Authentication authentication) {
         if (authentication == null) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Not authenticated");
         }
 
-        return ResponseEntity.ok(categoryService.getCategories(authentication.getName()));
+        return authentication.getName();
     }
 }

--- a/backend/src/main/java/br/com/calendar/category/CategoryMapper.java
+++ b/backend/src/main/java/br/com/calendar/category/CategoryMapper.java
@@ -1,10 +1,19 @@
 package br.com.calendar.category;
 
+import br.com.calendar.category.dto.CategoryRequestDTO;
 import br.com.calendar.category.dto.CategoryResponseDTO;
 import org.springframework.stereotype.Component;
 
 @Component
 public class CategoryMapper {
+
+    public Category toEntity(CategoryRequestDTO request) {
+        Category category = new Category();
+        category.setTitle(request.title());
+        category.setColor(request.color());
+        category.setIcon(request.icon());
+        return category;
+    }
 
     public CategoryResponseDTO toResponse(Category category) {
         return new CategoryResponseDTO(

--- a/backend/src/main/java/br/com/calendar/category/CategoryService.java
+++ b/backend/src/main/java/br/com/calendar/category/CategoryService.java
@@ -6,17 +6,34 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import br.com.calendar.category.dto.CategoryRequestDTO;
 import br.com.calendar.category.dto.CategoryResponseDTO;
+import br.com.calendar.common.exception.ResourceNotFoundException;
+import br.com.calendar.user.User;
+import br.com.calendar.user.UserRepository;
 
 @Service
 public class CategoryService {
 
     private final CategoryRepository categoryRepository;
     private final CategoryMapper categoryMapper;
+    private final UserRepository userRepository;
 
-    public CategoryService(CategoryRepository categoryRepository, CategoryMapper categoryMapper) {
+    public CategoryService(CategoryRepository categoryRepository, CategoryMapper categoryMapper,
+                           UserRepository userRepository) {
         this.categoryRepository = categoryRepository;
         this.categoryMapper = categoryMapper;
+        this.userRepository = userRepository;
+    }
+
+    public CategoryResponseDTO createCategory(CategoryRequestDTO request, String userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+
+        Category category = categoryMapper.toEntity(request);
+        category.setUser(user);
+
+        return categoryMapper.toResponse(categoryRepository.save(category));
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/br/com/calendar/category/dto/CategoryRequestDTO.java
+++ b/backend/src/main/java/br/com/calendar/category/dto/CategoryRequestDTO.java
@@ -1,6 +1,9 @@
 package br.com.calendar.category.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record CategoryRequestDTO(
+        @NotBlank(message = "Title is required.")
         String title,
         String color,
         String icon) {

--- a/backend/src/main/java/br/com/calendar/category/dto/CategoryRequestDTO.java
+++ b/backend/src/main/java/br/com/calendar/category/dto/CategoryRequestDTO.java
@@ -1,0 +1,7 @@
+package br.com.calendar.category.dto;
+
+public record CategoryRequestDTO(
+        String title,
+        String color,
+        String icon) {
+}

--- a/backend/src/test/java/br/com/calendar/category/CategoryControllerTest.java
+++ b/backend/src/test/java/br/com/calendar/category/CategoryControllerTest.java
@@ -1,9 +1,11 @@
 package br.com.calendar.category;
 
+import br.com.calendar.category.dto.CategoryRequestDTO;
 import br.com.calendar.category.dto.CategoryResponseDTO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.http.MediaType;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -15,6 +17,7 @@ import java.util.List;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -33,6 +36,26 @@ class CategoryControllerTest {
         mockMvc = MockMvcBuilders
                 .standaloneSetup(new CategoryController(categoryService))
                 .build();
+    }
+
+    @Test
+    void createsCategoryForTheAuthenticatedUser() throws Exception {
+        CategoryRequestDTO request = new CategoryRequestDTO("Work", "3366FF", "briefcase");
+        CategoryResponseDTO expected = new CategoryResponseDTO(
+                "cat_123", "Work", "3366FF", "briefcase");
+        when(categoryService.createCategory(request, USER_ID)).thenReturn(expected);
+
+        mockMvc.perform(post("/categories")
+                        .principal(new UsernamePasswordAuthenticationToken(USER_ID, null))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"title\":\"Work\",\"color\":\"3366FF\",\"icon\":\"briefcase\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value("cat_123"))
+                .andExpect(jsonPath("$.title").value("Work"))
+                .andExpect(jsonPath("$.color").value("3366FF"))
+                .andExpect(jsonPath("$.icon").value("briefcase"));
+
+        verify(categoryService).createCategory(request, USER_ID);
     }
 
     @Test

--- a/backend/src/test/java/br/com/calendar/category/CategoryControllerTest.java
+++ b/backend/src/test/java/br/com/calendar/category/CategoryControllerTest.java
@@ -2,9 +2,12 @@ package br.com.calendar.category;
 
 import br.com.calendar.category.dto.CategoryRequestDTO;
 import br.com.calendar.category.dto.CategoryResponseDTO;
+import br.com.calendar.common.exception.GlobalExceptionHandler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.http.MediaType;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -15,6 +18,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import java.util.List;
 
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -35,6 +39,7 @@ class CategoryControllerTest {
     void setUp() {
         mockMvc = MockMvcBuilders
                 .standaloneSetup(new CategoryController(categoryService))
+                .setControllerAdvice(new GlobalExceptionHandler())
                 .build();
     }
 
@@ -56,6 +61,20 @@ class CategoryControllerTest {
                 .andExpect(jsonPath("$.icon").value("briefcase"));
 
         verify(categoryService).createCategory(request, USER_ID);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"{}", "{\"title\":null}", "{\"title\":\"   \"}"})
+    void rejectsCategoryWhenTitleIsMissingOrBlank(String content) throws Exception {
+        mockMvc.perform(post("/categories")
+                        .principal(new UsernamePasswordAuthenticationToken(USER_ID, null))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(content))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.detail").value("Invalid fields"))
+                .andExpect(jsonPath("$.fields.title").value("Title is required."));
+
+        verifyNoInteractions(categoryService);
     }
 
     @Test

--- a/backend/src/test/java/br/com/calendar/category/CategoryServiceTest.java
+++ b/backend/src/test/java/br/com/calendar/category/CategoryServiceTest.java
@@ -1,16 +1,25 @@
 package br.com.calendar.category;
 
+import br.com.calendar.category.dto.CategoryRequestDTO;
 import br.com.calendar.category.dto.CategoryResponseDTO;
+import br.com.calendar.common.exception.ResourceNotFoundException;
+import br.com.calendar.user.User;
+import br.com.calendar.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -26,11 +35,51 @@ class CategoryServiceTest {
     @Mock
     private CategoryMapper categoryMapper;
 
+    @Mock
+    private UserRepository userRepository;
+
     private CategoryService categoryService;
 
     @BeforeEach
     void setUp() {
-        categoryService = new CategoryService(categoryRepository, categoryMapper);
+        categoryService = new CategoryService(categoryRepository, categoryMapper, userRepository);
+    }
+
+    @Test
+    void createsCategoryWithRequestFieldsAndAuthenticatedOwner() {
+        CategoryRequestDTO request = new CategoryRequestDTO("Work", "3366FF", "briefcase");
+        User user = new User();
+        user.setId(USER_ID);
+
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        when(categoryRepository.save(any(Category.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        CategoryResponseDTO response = new CategoryService(
+                categoryRepository, new CategoryMapper(), userRepository)
+                .createCategory(request, USER_ID);
+
+        ArgumentCaptor<Category> savedCategory = ArgumentCaptor.forClass(Category.class);
+        verify(categoryRepository).save(savedCategory.capture());
+
+        assertEquals("Work", savedCategory.getValue().getTitle());
+        assertEquals("3366FF", savedCategory.getValue().getColor());
+        assertEquals("briefcase", savedCategory.getValue().getIcon());
+        assertSame(user, savedCategory.getValue().getUser());
+        assertEquals("Work", response.title());
+        assertEquals("3366FF", response.color());
+        assertEquals("briefcase", response.icon());
+    }
+
+    @Test
+    void doesNotCreateCategoryWhenAuthenticatedUserDoesNotExist() {
+        CategoryRequestDTO request = new CategoryRequestDTO("Work", "3366FF", "briefcase");
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class,
+                () -> categoryService.createCategory(request, USER_ID));
+
+        verifyNoInteractions(categoryRepository, categoryMapper);
     }
 
     @Test


### PR DESCRIPTION
## Description

Implements the category creation endpoint.

- Adds `POST /categories`
- Accepts `title`, `color`, and `icon`
- Associates the category with the authenticated user
- Returns `201 Created` with `CategoryResponseDTO`
- Adds controller and service tests
- No database migrations or security configuration changes were required

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Infrastructure / CI / CD / Docker
- [ ] Other:

## Affected module(s)

- [x] backend
- [ ] frontend
- [ ] desktop
- [ ] mobile
- [ ] infra (docker / CI / CD)

## Checklist

- [ ] I ran the tests locally and they passed
- [ ] I updated the documentation (README/CONTRIBUTING), if necessary
- [x] I did not leave any console.log / System.out.println / print debug statements
- [x] I followed the project's commit convention (Conventional Commits)
- [x] I reviewed my own diff before opening the PR

Closes #113