### PR TITLE
feat(frontend): create reset password view

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -17,6 +17,12 @@ export const routes: Routes = [
     title: 'Entrar',
   },
   {
+    path: 'resetar-senha',
+    loadComponent: () =>
+      import('./pages/reset-password/reset-password').then((m) => m.ResetPassword),
+    title: 'Resetar senha',
+  },
+  {
     path: '',
     pathMatch: 'full',
     redirectTo: 'signup',

--- a/frontend/src/app/pages/reset-password/reset-password.css
+++ b/frontend/src/app/pages/reset-password/reset-password.css
@@ -1,0 +1,51 @@
+:host {
+  display: block;
+  min-height: 100dvh;
+}
+
+.reset-shell {
+  box-shadow: 0 24px 65px -32px rgb(31 41 55 / 0.3);
+}
+
+.brand-panel {
+  background: linear-gradient(145deg, #4c9cf5 0%, #3479ef 100%);
+}
+
+.field-shell {
+  border-color: #d6dae6;
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    background-color 160ms ease;
+}
+
+.field-shell:hover {
+  border-color: #b9c0d0;
+}
+
+.field-shell:focus-within {
+  border-color: #3b82f6;
+  background-color: #fff;
+  box-shadow: 0 0 0 3px rgb(59 130 246 / 0.12);
+}
+
+.field-shell.field-error {
+  border-color: #f87171;
+}
+
+.field-shell.field-error:focus-within {
+  box-shadow: 0 0 0 3px rgb(248 113 113 / 0.12);
+}
+
+.error-message {
+  margin-top: 6px;
+  color: #dc2626;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+@media (max-width: 639px) {
+  .reset-shell {
+    min-height: calc(100dvh - 32px);
+  }
+}

--- a/frontend/src/app/pages/reset-password/reset-password.html
+++ b/frontend/src/app/pages/reset-password/reset-password.html
@@ -1,0 +1,256 @@
+<main
+  class="min-h-screen bg-[#f0f2fb] p-4 sm:p-8 lg:p-10 flex items-center justify-center"
+  aria-labelledby="reset-password-title"
+>
+  <div
+    class="reset-shell w-full max-w-[1200px] min-h-[680px] lg:min-h-[748px] grid lg:grid-cols-2 overflow-hidden rounded-2xl bg-white border border-gray-200/80"
+  >
+    <aside
+      class="brand-panel hidden lg:flex flex-col justify-between p-12 xl:p-14 text-white"
+      aria-label="Apresentação do Project A"
+    >
+      <div>
+        <a routerLink="/login" class="inline-flex items-center gap-3 text-white no-underline">
+          <span
+            class="flex h-12 w-12 items-center justify-center rounded-xl border border-white/30 bg-white/15 shadow-lg"
+            aria-hidden="true"
+          >
+            <svg
+              class="h-6 w-6"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+            >
+              <rect width="18" height="18" x="3" y="4" rx="2" />
+              <path d="M3 10h18M8 2v4M16 2v4" />
+            </svg>
+          </span>
+          <span class="text-2xl font-bold">Project A</span>
+        </a>
+
+        <div class="mt-20 max-w-md">
+          <p class="text-5xl xl:text-[52px] font-extrabold leading-[1.15] tracking-tight">
+            Foque no que<br />mais importa.
+          </p>
+          <p class="mt-7 max-w-sm text-base leading-7 text-white/90">
+            Junte-se a milhares de profissionais que utilizam o ambiente de agendamento mais
+            intuitivo e livre de distrações.
+          </p>
+        </div>
+      </div>
+
+      <div
+        class="flex max-w-[504px] items-center gap-4 rounded-2xl border border-white/25 bg-white/10 p-5"
+      >
+        <span
+          class="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-white text-[#3b82f6]"
+          aria-hidden="true"
+        >
+          <svg
+            class="h-6 w-6"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.8"
+            viewBox="0 0 24 24"
+          >
+            <path d="m12 3-1.2 3.3L7.5 7.5l3.3 1.2L12 12l1.2-3.3 3.3-1.2-3.3-1.2L12 3Z" />
+            <path d="m6 13-.8 2.2L3 16l2.2.8L6 19l.8-2.2L9 16l-2.2-.8L6 13Z" />
+            <path d="m17.5 14-.7 1.8-1.8.7 1.8.7.7 1.8.7-1.8 1.8-.7-1.8-.7-.7-1.8Z" />
+          </svg>
+        </span>
+        <div>
+          <p class="text-xs font-semibold uppercase tracking-[0.14em] text-white/75">
+            Segurança da conta
+          </p>
+          <p class="mt-1 text-sm text-white/95">
+            Escolha uma senha nova e mantenha seus dados protegidos.
+          </p>
+        </div>
+      </div>
+    </aside>
+
+    <section class="flex flex-col bg-white px-6 py-8 sm:px-12 lg:px-16 xl:px-20">
+      <div class="lg:hidden mb-12 flex items-center gap-3 text-[#111827]">
+        <span
+          class="flex h-10 w-10 items-center justify-center rounded-xl bg-[#3b82f6] text-white"
+          aria-hidden="true"
+        >
+          <svg
+            class="h-5 w-5"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+          >
+            <rect width="18" height="18" x="3" y="4" rx="2" />
+            <path d="M3 10h18M8 2v4M16 2v4" />
+          </svg>
+        </span>
+        <span class="text-xl font-bold">Project A</span>
+      </div>
+
+      <div class="m-auto w-full max-w-[400px]">
+        <header class="mb-12">
+          <h1 id="reset-password-title" class="text-3xl font-bold tracking-tight text-[#171923]">
+            Redefinir senha
+          </h1>
+          <p class="mt-2 text-sm leading-6 text-gray-600">
+            Crie uma nova senha para acessar sua conta.
+          </p>
+        </header>
+
+        @if (generalError()) {
+          <div
+            class="mb-5 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700"
+            role="alert"
+            aria-live="polite"
+          >
+            {{ generalError() }}
+          </div>
+        }
+
+        <form [formGroup]="form" (ngSubmit)="onSubmit()" novalidate class="space-y-6">
+          <div>
+            <label for="password" class="mb-2 block text-xs font-semibold text-gray-700">
+              Nova senha
+            </label>
+            <div
+              class="field-shell flex items-center rounded-xl border bg-[#f8f9fe] px-3.5"
+              [class.field-error]="
+                showError('password', 'required') ||
+                showError('password', 'minlength') ||
+                showError('password', 'pattern')
+              "
+            >
+              <svg
+                class="h-5 w-5 shrink-0 text-gray-500"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <rect width="14" height="11" x="5" y="10" rx="2" />
+                <path d="M8 10V7a4 4 0 0 1 8 0v3" />
+              </svg>
+              <input
+                id="password"
+                [type]="showPassword() ? 'text' : 'password'"
+                formControlName="password"
+                autocomplete="new-password"
+                placeholder="Mínimo de 8 caracteres"
+                class="h-12 min-w-0 flex-1 bg-transparent px-3 text-sm text-gray-900 outline-none placeholder:text-gray-400"
+                aria-describedby="password-error"
+                [attr.aria-invalid]="
+                  showError('password', 'required') ||
+                  showError('password', 'minlength') ||
+                  showError('password', 'pattern')
+                "
+              />
+              <button
+                type="button"
+                class="rounded-md p-1 text-gray-500 hover:text-[#2563eb] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#2563eb]"
+                (click)="togglePasswordVisibility()"
+                [attr.aria-label]="showPassword() ? 'Ocultar senhas' : 'Mostrar senhas'"
+              >
+                <svg
+                  class="h-5 w-5"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  @if (showPassword()) {
+                    <path
+                      d="m3 3 18 18M10.6 10.7a2 2 0 0 0 2.7 2.7M9.9 4.2A10.9 10.9 0 0 1 12 4c5 0 9 4 10 8a13.4 13.4 0 0 1-2.1 4.2M6.6 6.6C4.3 8 2.7 10 2 12c1 4 5 8 10 8a10.8 10.8 0 0 0 4.3-.9"
+                    />
+                  } @else {
+                    <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7S2 12 2 12Z" />
+                    <circle cx="12" cy="12" r="3" />
+                  }
+                </svg>
+              </button>
+            </div>
+
+            @if (showError('password', 'required')) {
+              <p id="password-error" class="error-message">Informe uma nova senha.</p>
+            } @else if (showError('password', 'minlength')) {
+              <p id="password-error" class="error-message">
+                A senha deve ter pelo menos 8 caracteres.
+              </p>
+            } @else if (showError('password', 'pattern')) {
+              <p id="password-error" class="error-message">A senha não pode conter emojis.</p>
+            }
+          </div>
+
+          <div>
+            <label
+              for="password_confirmation"
+              class="mb-2 block text-xs font-semibold text-gray-700"
+            >
+              Confirmar nova senha
+            </label>
+            <div
+              class="field-shell flex items-center rounded-xl border bg-[#f8f9fe] px-3.5"
+              [class.field-error]="
+                showError('password_confirmation', 'required') ||
+                showError('password_confirmation', 'passwordsMismatch')
+              "
+            >
+              <svg
+                class="h-5 w-5 shrink-0 text-gray-500"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <rect width="14" height="11" x="5" y="10" rx="2" />
+                <path d="M8 10V7a4 4 0 0 1 8 0v3" />
+              </svg>
+              <input
+                id="password_confirmation"
+                [type]="showPassword() ? 'text' : 'password'"
+                formControlName="password_confirmation"
+                autocomplete="new-password"
+                placeholder="Repita a nova senha"
+                class="h-12 min-w-0 flex-1 bg-transparent px-3 text-sm text-gray-900 outline-none placeholder:text-gray-400"
+                aria-describedby="password-confirmation-error"
+                [attr.aria-invalid]="
+                  showError('password_confirmation', 'required') ||
+                  showError('password_confirmation', 'passwordsMismatch')
+                "
+              />
+            </div>
+
+            @if (showError('password_confirmation', 'required')) {
+              <p id="password-confirmation-error" class="error-message">Confirme a nova senha.</p>
+            } @else if (showError('password_confirmation', 'passwordsMismatch')) {
+              <p id="password-confirmation-error" class="error-message">As senhas não coincidem.</p>
+            }
+          </div>
+
+          <button
+            type="submit"
+            class="h-[58px] w-full rounded-xl bg-[#3b82f6] text-base font-bold text-white shadow-sm transition hover:bg-[#2563eb] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#2563eb] active:scale-[0.99]"
+          >
+            Resetar senha
+          </button>
+        </form>
+
+        <p class="mt-10 text-center text-sm text-gray-600">
+          Lembrou sua senha?
+          <a routerLink="/login" class="ml-1 font-semibold text-[#2563eb] hover:underline">
+            Voltar para o login
+          </a>
+        </p>
+      </div>
+
+      <footer class="mt-12 text-center text-xs font-medium text-gray-400">
+        &copy; 2026 Project A. Gestão profissional de horários.
+      </footer>
+    </section>
+  </div>
+</main>

--- a/frontend/src/app/pages/reset-password/reset-password.spec.ts
+++ b/frontend/src/app/pages/reset-password/reset-password.spec.ts
@@ -1,0 +1,107 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { ResetPassword } from './reset-password';
+
+describe('ResetPassword', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ResetPassword],
+      providers: [provideRouter([])],
+    }).compileComponents();
+  });
+
+  function createComponent() {
+    const fixture = TestBed.createComponent(ResetPassword);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  it('should render the required fields, submit button, and login navigation', () => {
+    const fixture = createComponent();
+    const element = fixture.nativeElement as HTMLElement;
+
+    expect(element.querySelector('input[formControlName="password"]')).toBeTruthy();
+    expect(element.querySelector('input[formControlName="password_confirmation"]')).toBeTruthy();
+    expect(element.querySelector('button[type="submit"]')?.textContent?.trim()).toBe(
+      'Resetar senha',
+    );
+    expect(element.querySelector('a[routerLink="/login"]')).toBeTruthy();
+  });
+
+  it('should show required errors after an invalid submit', () => {
+    const fixture = createComponent();
+    const component = fixture.componentInstance as any;
+
+    component.onSubmit();
+    fixture.detectChanges();
+
+    const element = fixture.nativeElement as HTMLElement;
+    expect(element.querySelector('#password-error')?.textContent).toContain(
+      'Informe uma nova senha.',
+    );
+    expect(element.querySelector('#password-confirmation-error')?.textContent).toContain(
+      'Confirme a nova senha.',
+    );
+  });
+
+  it('should require a password with at least eight characters', () => {
+    const fixture = createComponent();
+    const component = fixture.componentInstance as any;
+
+    component.form.patchValue({ password: '1234567' });
+    component.onSubmit();
+    fixture.detectChanges();
+
+    const element = fixture.nativeElement as HTMLElement;
+    expect(element.querySelector('#password-error')?.textContent).toContain(
+      'A senha deve ter pelo menos 8 caracteres.',
+    );
+  });
+
+  it('should show an error when passwords do not match', () => {
+    const fixture = createComponent();
+    const component = fixture.componentInstance as any;
+
+    component.form.setValue({
+      password: 'secure-password',
+      password_confirmation: 'different-password',
+    });
+    component.onSubmit();
+    fixture.detectChanges();
+
+    const element = fixture.nativeElement as HTMLElement;
+    expect(element.querySelector('#password-confirmation-error')?.textContent).toContain(
+      'As senhas não coincidem.',
+    );
+    expect(component.form.invalid).toBe(true);
+  });
+
+  it('should accept matching valid passwords', () => {
+    const fixture = createComponent();
+    const component = fixture.componentInstance as any;
+
+    component.form.setValue({
+      password: 'secure-password',
+      password_confirmation: 'secure-password',
+    });
+
+    expect(component.form.valid).toBe(true);
+  });
+
+  it('should toggle both password fields between password and text', () => {
+    const fixture = createComponent();
+    const component = fixture.componentInstance as any;
+    const element = fixture.nativeElement as HTMLElement;
+    const passwordInput = element.querySelector('#password') as HTMLInputElement;
+    const confirmationInput = element.querySelector('#password_confirmation') as HTMLInputElement;
+
+    expect(passwordInput.type).toBe('password');
+    expect(confirmationInput.type).toBe('password');
+
+    component.togglePasswordVisibility();
+    fixture.detectChanges();
+
+    expect(passwordInput.type).toBe('text');
+    expect(confirmationInput.type).toBe('text');
+  });
+});

--- a/frontend/src/app/pages/reset-password/reset-password.ts
+++ b/frontend/src/app/pages/reset-password/reset-password.ts
@@ -1,0 +1,81 @@
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import {
+  AbstractControl,
+  ReactiveFormsModule,
+  ValidationErrors,
+  ValidatorFn,
+  Validators,
+  NonNullableFormBuilder,
+} from '@angular/forms';
+import { RouterLink } from '@angular/router';
+
+type ResetPasswordField = 'password' | 'password_confirmation';
+
+const PASSWORD_PATTERN = /^[\x20-\x7E]+$/;
+
+function passwordsMatchValidator(): ValidatorFn {
+  return (group: AbstractControl): ValidationErrors | null => {
+    const password = group.get('password')?.value;
+    const passwordConfirmation = group.get('password_confirmation')?.value;
+
+    if (!passwordConfirmation) {
+      return null;
+    }
+
+    return password === passwordConfirmation ? null : { passwordsMismatch: true };
+  };
+}
+
+@Component({
+  selector: 'app-reset-password',
+  standalone: true,
+  imports: [ReactiveFormsModule, RouterLink],
+  templateUrl: './reset-password.html',
+  styleUrl: './reset-password.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ResetPassword {
+  private readonly formBuilder = inject(NonNullableFormBuilder);
+
+  protected readonly submitted = signal(false);
+  protected readonly showPassword = signal(false);
+  protected readonly generalError = signal<string | null>(null);
+
+  protected readonly form = this.formBuilder.group(
+    {
+      password: [
+        '',
+        [Validators.required, Validators.minLength(8), Validators.pattern(PASSWORD_PATTERN)],
+      ],
+      password_confirmation: ['', Validators.required],
+    },
+    { validators: passwordsMatchValidator() },
+  );
+
+  protected showError(field: ResetPasswordField, errorCode: string): boolean {
+    const control = this.form.controls[field];
+    const shouldShow = control.touched || this.submitted();
+
+    if (errorCode === 'passwordsMismatch') {
+      return shouldShow && this.form.hasError('passwordsMismatch') && !!control.value;
+    }
+
+    return shouldShow && control.hasError(errorCode);
+  }
+
+  protected togglePasswordVisibility(): void {
+    this.showPassword.update((isVisible) => !isVisible);
+  }
+
+  protected onSubmit(): void {
+    this.submitted.set(true);
+    this.generalError.set(null);
+
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    // API integration is intentionally outside the scope of issue #30.
+  }
+}


### PR DESCRIPTION
## Description

Creates the reset password view based on the project's existing visual language.

The page includes a responsive layout, reactive form validation, password confirmation, password visibility control, validation messages, and navigation back to the login page.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Infrastructure / CI / CD / Docker
- [ ] Other:

## Affected module(s)

- [ ] backend
- [x] frontend
- [ ] desktop
- [ ] mobile
- [ ] infra (docker / CI / CD)

## Validation

- Added unit tests for required fields, minimum password length, password matching, and password visibility.
- Verified responsive layouts on desktop and mobile.
- Ran the frontend test suite successfully: 14 tests passed.
- Ran the production SSR build successfully.

## Screenshots
<img width="1782" height="952" alt="image" src="https://github.com/user-attachments/assets/95d4d883-cdac-40ac-b39d-088bc29b030b" />



## Checklist

- [x] I ran the tests locally and they passed
- [x] I updated the documentation, if necessary
- [x] I did not leave any debug statements
- [x] I followed the project's commit convention
- [x] I reviewed my own diff before opening the PR

## Related issue
 
Closes #30 