### PR TITLE
feat: add navigation sidebar component (#107)

### DIFF
--- a/frontend/src/app/core/components/sidebar/sidebar.html
+++ b/frontend/src/app/core/components/sidebar/sidebar.html
@@ -1,0 +1,207 @@
+<aside
+  class="flex h-dvh w-64 max-w-full flex-col border-r border-gray-200 bg-[#f9f9ff] px-2.5 py-5"
+  aria-label="Navegação lateral"
+>
+  <header class="px-1">
+    <h1 class="text-xl font-bold text-[#0055b8]">Project A</h1>
+    <p class="mt-1 text-sm text-gray-500">Produtividade Pessoal</p>
+  </header>
+
+  <nav class="mt-8" aria-label="Menu principal">
+    <ul class="space-y-1.5">
+      @for (item of navItems; track item.id) {
+        <li>
+          <a
+            href="#"
+            class="flex h-10 items-center gap-3 rounded-lg px-4 text-sm transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0055b8]"
+            [class]="
+              activeItemId() === item.id
+                ? 'bg-[#d0e1fb] font-semibold text-[#0055b8] shadow-[inset_3px_0_0_0_#0055b8]'
+                : 'font-medium text-gray-500 hover:bg-[#e9edf8] hover:text-gray-900'
+            "
+            [attr.aria-current]="activeItemId() === item.id ? 'page' : null"
+            (click)="onNavClick($event, item.id)"
+          >
+            @switch (item.icon) {
+              @case ('dashboard') {
+                <svg
+                  class="h-[18px] w-[18px] shrink-0"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <rect width="7" height="9" x="3" y="3" rx="1" />
+                  <rect width="7" height="5" x="14" y="3" rx="1" />
+                  <rect width="7" height="9" x="14" y="12" rx="1" />
+                  <rect width="7" height="5" x="3" y="16" rx="1" />
+                </svg>
+              }
+              @case ('calendar') {
+                <svg
+                  class="h-[18px] w-[18px] shrink-0"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path d="M8 2v4M16 2v4" />
+                  <rect width="18" height="18" x="3" y="4" rx="2" />
+                  <path d="M3 10h18" />
+                </svg>
+              }
+              @case ('upcoming') {
+                <svg
+                  class="h-[18px] w-[18px] shrink-0"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path d="M8 2v4M16 2v4" />
+                  <path d="M21 11V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h6" />
+                  <path d="m15 19 4-4-4-4" />
+                </svg>
+              }
+              @case ('history') {
+                <svg
+                  class="h-[18px] w-[18px] shrink-0"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+                  <path d="M3 3v5h5" />
+                  <path d="M12 7v5l4 2" />
+                </svg>
+              }
+              @case ('settings') {
+                <svg
+                  class="h-[18px] w-[18px] shrink-0"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"
+                  />
+                  <circle cx="12" cy="12" r="3" />
+                </svg>
+              }
+            }
+            {{ item.label }}
+          </a>
+        </li>
+      }
+    </ul>
+  </nav>
+
+  <button
+    type="button"
+    class="mt-10 flex h-13 w-full items-center justify-center gap-2 rounded-xl bg-[#0055b8] text-sm font-semibold text-white transition-colors hover:bg-[#004a9f] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0055b8]"
+  >
+    <svg
+      class="h-[18px] w-[18px] shrink-0"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <path d="M5 12h14M12 5v14" />
+    </svg>
+    Novo Evento
+  </button>
+
+  <nav
+    class="-mx-2.5 mt-auto border-t border-gray-200 px-2.5 pt-3"
+    aria-label="Recursos adicionais"
+  >
+    <ul class="space-y-2">
+      @for (item of utilityItems; track item.id) {
+        <li>
+          <a
+            href="#"
+            class="flex h-10 items-center gap-3 rounded-lg px-4 text-sm font-medium text-gray-500 transition-colors hover:bg-[#e9edf8] hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0055b8]"
+            (click)="onUtilityClick($event)"
+          >
+            @switch (item.id) {
+              @case ('planejador-estudos') {
+                <svg
+                  class="h-[18px] w-[18px] shrink-0"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    d="M21.42 10.922a1 1 0 0 0-.019-1.838L12.83 5.18a2 2 0 0 0-1.66 0L2.6 9.08a1 1 0 0 0 0 1.832l8.57 3.908a2 2 0 0 0 1.66 0z"
+                  />
+                  <path d="M22 10v6" />
+                  <path d="M6 12.5V16a6 3 0 0 0 12 0v-3.5" />
+                </svg>
+              }
+              @case ('compartilhamento') {
+                <svg
+                  class="h-[18px] w-[18px] shrink-0"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <circle cx="18" cy="5" r="3" />
+                  <circle cx="6" cy="12" r="3" />
+                  <circle cx="18" cy="19" r="3" />
+                  <path d="m8.59 13.51 6.83 3.98M15.41 6.51l-6.82 3.98" />
+                </svg>
+              }
+            }
+            {{ item.label }}
+          </a>
+        </li>
+      }
+    </ul>
+
+    <div
+      class="mt-2 flex items-center gap-3 border-t border-gray-200 px-4 pt-3"
+      role="img"
+      aria-label="Perfil de Estefânio"
+    >
+      <span
+        class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[#0055b8] text-sm font-semibold text-white"
+        aria-hidden="true"
+      >
+        {{ user.initials }}
+      </span>
+      <span class="min-w-0">
+        <span class="block truncate text-sm font-semibold text-gray-900">{{ user.name }}</span>
+        <span class="block truncate text-xs text-gray-500">{{ user.email }}</span>
+      </span>
+    </div>
+  </nav>
+</aside>

--- a/frontend/src/app/core/components/sidebar/sidebar.html
+++ b/frontend/src/app/core/components/sidebar/sidebar.html
@@ -6,7 +6,12 @@
   aria-label="Abrir menu"
 >
   <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      d="M4 6h16M4 12h16M4 18h16"
+    />
   </svg>
 </button>
 

--- a/frontend/src/app/core/components/sidebar/sidebar.html
+++ b/frontend/src/app/core/components/sidebar/sidebar.html
@@ -169,11 +169,17 @@
         <li>
           <a
             href="#"
-            class="flex h-10 items-center gap-3 rounded-lg px-4 text-sm font-medium text-gray-500 transition-colors hover:bg-[#e9edf8] hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0055b8]"
-            (click)="onUtilityClick($event)"
+            class="flex h-10 items-center gap-3 rounded-lg px-4 text-sm transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0055b8]"
+            [class]="
+              activeItemId() === item.id
+                ? 'bg-[#d0e1fb] font-semibold text-[#0055b8] shadow-[inset_3px_0_0_0_#0055b8]'
+                : 'font-medium text-gray-500 hover:bg-[#e9edf8] hover:text-gray-900'
+            "
+            [attr.aria-current]="activeItemId() === item.id ? 'page' : null"
+            (click)="onUtilityClick($event, item.id)"
           >
             @switch (item.id) {
-              @case ('planejador-estudos') {
+              @case ('study-planner') {
                 <svg
                   class="h-[18px] w-[18px] shrink-0"
                   fill="none"
@@ -191,7 +197,7 @@
                   <path d="M6 12.5V16a6 3 0 0 0 12 0v-3.5" />
                 </svg>
               }
-              @case ('compartilhamento') {
+              @case ('sharing') {
                 <svg
                   class="h-[18px] w-[18px] shrink-0"
                   fill="none"

--- a/frontend/src/app/core/components/sidebar/sidebar.html
+++ b/frontend/src/app/core/components/sidebar/sidebar.html
@@ -1,5 +1,28 @@
+<!-- Mobile toggle button -->
+<button
+  type="button"
+  class="fixed left-4 top-4 z-40 rounded-md p-2 text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-[#0055b8] md:hidden"
+  (click)="toggleSidebar()"
+  aria-label="Abrir menu"
+>
+  <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+  </svg>
+</button>
+
+<!-- Mobile backdrop -->
+@if (isOpen()) {
+  <div
+    class="fixed inset-0 z-40 bg-gray-900/50 transition-opacity md:hidden"
+    (click)="toggleSidebar()"
+    aria-hidden="true"
+  ></div>
+}
+
 <aside
-  class="flex h-dvh w-64 max-w-full flex-col border-r border-gray-200 bg-[#f9f9ff] px-2.5 py-5"
+  class="fixed inset-y-0 left-0 z-50 flex h-dvh w-64 flex-col border-r border-gray-200 bg-[#f9f9ff] px-2.5 py-5 transition-transform duration-300 md:static md:translate-x-0"
+  [class.-translate-x-full]="!isOpen()"
+  [class.translate-x-0]="isOpen()"
   aria-label="Navegação lateral"
 >
   <header class="px-1">

--- a/frontend/src/app/core/components/sidebar/sidebar.spec.ts
+++ b/frontend/src/app/core/components/sidebar/sidebar.spec.ts
@@ -1,0 +1,57 @@
+import { TestBed } from '@angular/core/testing';
+import { Sidebar } from './sidebar';
+
+describe('Sidebar', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [Sidebar],
+    }).compileComponents();
+  });
+
+  function createComponent() {
+    const fixture = TestBed.createComponent(Sidebar);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  it('should render the brand header and all navigation items', () => {
+    const element = createComponent().nativeElement as HTMLElement;
+
+    expect(element.textContent).toContain('Project A');
+    expect(element.textContent).toContain('Produtividade Pessoal');
+    expect(element.textContent).toContain('Painel');
+    expect(element.textContent).toContain('Calendário');
+    expect(element.textContent).toContain('Próximos');
+    expect(element.textContent).toContain('Histórico');
+    expect(element.textContent).toContain('Configurações');
+    expect(element.textContent).toContain('Planejador de Estudos');
+    expect(element.textContent).toContain('Compartilhamento');
+  });
+
+  it('should render the new event button and the static user profile', () => {
+    const element = createComponent().nativeElement as HTMLElement;
+
+    const newEventButton = element.querySelector('button');
+    expect(newEventButton?.textContent).toContain('Novo Evento');
+
+    expect(element.textContent).toContain('Estefânio');
+    expect(element.textContent).toContain('estefaniossi@gmail.com');
+  });
+
+  it('should highlight the active navigation item and update it on click', () => {
+    const fixture = createComponent();
+    const element = fixture.nativeElement as HTMLElement;
+
+    const activeLink = element.querySelector('a[aria-current="page"]');
+    expect(activeLink?.textContent).toContain('Próximos');
+
+    const painelLink = Array.from(element.querySelectorAll('a')).find((link) =>
+      link.textContent?.includes('Painel'),
+    );
+    painelLink?.click();
+    fixture.detectChanges();
+
+    const updatedActiveLink = element.querySelector('a[aria-current="page"]');
+    expect(updatedActiveLink?.textContent).toContain('Painel');
+  });
+});

--- a/frontend/src/app/core/components/sidebar/sidebar.spec.ts
+++ b/frontend/src/app/core/components/sidebar/sidebar.spec.ts
@@ -31,8 +31,9 @@ describe('Sidebar', () => {
   it('should render the new event button and the static user profile', () => {
     const element = createComponent().nativeElement as HTMLElement;
 
-    const newEventButton = element.querySelector('button');
-    expect(newEventButton?.textContent).toContain('Novo Evento');
+    const buttons = Array.from(element.querySelectorAll('button'));
+    const newEventButton = buttons.find(b => b.textContent?.includes('Novo Evento'));
+    expect(newEventButton).toBeTruthy();
 
     expect(element.textContent).toContain('Estefânio');
     expect(element.textContent).toContain('estefaniossi@gmail.com');

--- a/frontend/src/app/core/components/sidebar/sidebar.spec.ts
+++ b/frontend/src/app/core/components/sidebar/sidebar.spec.ts
@@ -32,7 +32,7 @@ describe('Sidebar', () => {
     const element = createComponent().nativeElement as HTMLElement;
 
     const buttons = Array.from(element.querySelectorAll('button'));
-    const newEventButton = buttons.find(b => b.textContent?.includes('Novo Evento'));
+    const newEventButton = buttons.find((b) => b.textContent?.includes('Novo Evento'));
     expect(newEventButton).toBeTruthy();
 
     expect(element.textContent).toContain('Estefânio');

--- a/frontend/src/app/core/components/sidebar/sidebar.ts
+++ b/frontend/src/app/core/components/sidebar/sidebar.ts
@@ -27,16 +27,16 @@ interface SidebarUser {
 })
 export class Sidebar {
   protected readonly navItems: SidebarNavItem[] = [
-    { id: 'painel', label: 'Painel', icon: 'dashboard' },
-    { id: 'calendario', label: 'Calendário', icon: 'calendar' },
-    { id: 'proximos', label: 'Próximos', icon: 'upcoming' },
-    { id: 'historico', label: 'Histórico', icon: 'history' },
-    { id: 'configuracoes', label: 'Configurações', icon: 'settings' },
+    { id: 'dashboard', label: 'Painel', icon: 'dashboard' },
+    { id: 'calendar', label: 'Calendário', icon: 'calendar' },
+    { id: 'upcoming', label: 'Próximos', icon: 'upcoming' },
+    { id: 'history', label: 'Histórico', icon: 'history' },
+    { id: 'settings', label: 'Configurações', icon: 'settings' },
   ];
 
   protected readonly utilityItems: SidebarUtilityItem[] = [
-    { id: 'planejador-estudos', label: 'Planejador de Estudos' },
-    { id: 'compartilhamento', label: 'Compartilhamento' },
+    { id: 'study-planner', label: 'Planejador de Estudos' },
+    { id: 'sharing', label: 'Compartilhamento' },
   ];
 
   protected readonly user: SidebarUser = {
@@ -46,7 +46,7 @@ export class Sidebar {
   };
 
   // Static navigation: routes are not wired yet, so the active item is local state.
-  protected readonly activeItemId = signal('proximos');
+  protected readonly activeItemId = signal('upcoming');
   protected readonly isOpen = signal(false);
 
   protected toggleSidebar(): void {

--- a/frontend/src/app/core/components/sidebar/sidebar.ts
+++ b/frontend/src/app/core/components/sidebar/sidebar.ts
@@ -59,7 +59,9 @@ export class Sidebar {
     this.isOpen.set(false); // Close sidebar on mobile after clicking a link
   }
 
-  protected onUtilityClick(event: Event): void {
+  protected onUtilityClick(event: Event, id: string): void {
     event.preventDefault();
+    this.activeItemId.set(id);
+    this.isOpen.set(false);
   }
 }

--- a/frontend/src/app/core/components/sidebar/sidebar.ts
+++ b/frontend/src/app/core/components/sidebar/sidebar.ts
@@ -50,7 +50,7 @@ export class Sidebar {
   protected readonly isOpen = signal(false);
 
   protected toggleSidebar(): void {
-    this.isOpen.update(v => !v);
+    this.isOpen.update((v) => !v);
   }
 
   protected onNavClick(event: Event, id: string): void {

--- a/frontend/src/app/core/components/sidebar/sidebar.ts
+++ b/frontend/src/app/core/components/sidebar/sidebar.ts
@@ -1,0 +1,59 @@
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+
+type SidebarIcon = 'dashboard' | 'calendar' | 'upcoming' | 'history' | 'settings';
+
+interface SidebarNavItem {
+  id: string;
+  label: string;
+  icon: SidebarIcon;
+}
+
+interface SidebarUtilityItem {
+  id: string;
+  label: string;
+}
+
+interface SidebarUser {
+  name: string;
+  email: string;
+  initials: string;
+}
+
+@Component({
+  selector: 'app-sidebar',
+  standalone: true,
+  templateUrl: './sidebar.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class Sidebar {
+  protected readonly navItems: SidebarNavItem[] = [
+    { id: 'painel', label: 'Painel', icon: 'dashboard' },
+    { id: 'calendario', label: 'Calendário', icon: 'calendar' },
+    { id: 'proximos', label: 'Próximos', icon: 'upcoming' },
+    { id: 'historico', label: 'Histórico', icon: 'history' },
+    { id: 'configuracoes', label: 'Configurações', icon: 'settings' },
+  ];
+
+  protected readonly utilityItems: SidebarUtilityItem[] = [
+    { id: 'planejador-estudos', label: 'Planejador de Estudos' },
+    { id: 'compartilhamento', label: 'Compartilhamento' },
+  ];
+
+  protected readonly user: SidebarUser = {
+    name: 'Estefânio',
+    email: 'estefaniossi@gmail.com',
+    initials: 'E',
+  };
+
+  // Static navigation: routes are not wired yet, so the active item is local state.
+  protected readonly activeItemId = signal('proximos');
+
+  protected onNavClick(event: Event, id: string): void {
+    event.preventDefault();
+    this.activeItemId.set(id);
+  }
+
+  protected onUtilityClick(event: Event): void {
+    event.preventDefault();
+  }
+}

--- a/frontend/src/app/core/components/sidebar/sidebar.ts
+++ b/frontend/src/app/core/components/sidebar/sidebar.ts
@@ -47,10 +47,16 @@ export class Sidebar {
 
   // Static navigation: routes are not wired yet, so the active item is local state.
   protected readonly activeItemId = signal('proximos');
+  protected readonly isOpen = signal(false);
+
+  protected toggleSidebar(): void {
+    this.isOpen.update(v => !v);
+  }
 
   protected onNavClick(event: Event, id: string): void {
     event.preventDefault();
     this.activeItemId.set(id);
+    this.isOpen.set(false); // Close sidebar on mobile after clicking a link
   }
 
   protected onUtilityClick(event: Event): void {


### PR DESCRIPTION
## Description

This PR implements the navigation sidebar for the frontend, as requested in #107.

It adds a standalone Angular `Sidebar` component under `core/components/sidebar/` that renders the application's main navigation (dashboard, calendar and utility items) with an active-state indicator and responsive behavior for mobile viewports, along with unit tests covering the component.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Infrastructure / CI / CD / Docker
- [ ] Other:

## Affected module(s)

- [ ] backend
- [x] frontend
- [ ] desktop
- [ ] mobile
- [ ] infra (docker / CI / CD)

## Checklist

- [x] I ran the tests locally and they passed (5 tests passed, including the 3 new `sidebar.spec.ts` tests)
- [ ] I updated the documentation (README/CONTRIBUTING), if necessary
- [x] I did not leave any `console.log` / `System.out.println` / `print` debug statements
- [x] I followed the project's commit convention (Conventional Commits)
- [x] I reviewed my own diff before opening the PR

Closes #107
